### PR TITLE
Add all previous primers

### DIFF
--- a/primers/1.19.3/forge.md
+++ b/primers/1.19.3/forge.md
@@ -1,0 +1,215 @@
+# Minecraft 1.19.2 -> 1.19.3 Forge Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.19.2 to 1.19.3 using Forge.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Vanilla Changes
+
+Vanilla changes are listed [here](./index.md).
+
+## Registry Order
+
+This is the current order in which registries are loaded:
+
+- `minecraft:instrument` (Everything above is the same as vanilla)
+- `forge:biome_modifier_serializers`
+- `forge:entity_data_serializers`
+- `forge:fluid_type`
+- `forge:global_loot_modifier_serializers`
+- `forge:holder_set_type`
+- `forge:structure_modifier_serializers`
+- `minecraft:worldgen/biome`
+
+## Existing Creative Tabs
+
+`CreativeModeTab`s are no longer set through a property on the item; they are harcoded onto the creative tab itself. To get around this, the `CreativeModeTabEvent` was added, allowing a modder to create a creative tab or add items to an existing creative tab. All events are on the **mod** event bus.
+
+### Adding Items
+
+Items can be added to a creative tab via `CreativeModeTabEvent$BuildContents`. The event contains the tab to add contents to, the set feature flags, and whether the user as OP permissions. An item can be added to the creative tab by calling `#accept` or `#acceptAll`. If you want to inject between an item already in the creative tab, you can call `MutableHashedLinkedMap#putBefore` or `MutableHashedLinkedMap#putAfter` within the provided entry list (`#getEntries`).
+
+```java
+// Registered on the MOD event bus
+// Assume we have RegistryObject<Item> and RegistryObject<Block> called ITEM and BLOCK
+@SubscribeEvent
+public void buildContents(CreativeModeTabEvent.BuildContents event) {
+  // Add to ingredients tab
+  if (event.getTab() == CreativeModeTabs.INGREDIENTS) {
+    event.accept(ITEM);
+    event.accept(BLOCK); // Takes in an ItemLike, assumes block has registered item
+  }
+}
+```
+
+### Custom Creative Tab
+
+A custom `CreativeModeTab` can be created via `CreativeModeTabEvent$Register#registerCreativeModeTab`. This takes in the name of the tab along with a consumer of the builder. An additional overload is specified to determine between which tabs this tab should be located.
+
+```java
+// Registered on the MOD event bus
+// Assume we have RegistryObject<Item> and RegistryObject<Block> called ITEM and BLOCK
+@SubscribeEvent
+public void buildContents(CreativeModeTabEvent.Register event) {
+  event.registerCreativeModeTab(new ResourceLocation(MOD_ID, "example"), builder ->
+    // Set name of tab to display
+    builder.title(Component.translatable("item_group." + MOD_ID + ".example"))
+    // Set icon of creative tab
+    .icon(() -> new ItemStack(ITEM.get()))
+    // Add default items to tab
+    .displayItems((enabledFlags, populator, hasPermissions) -> {
+      populator.accept(ITEM.get());
+      populator.accept(BLOCK.get());
+    })
+  );
+}
+```
+
+## Packs and PackResources
+
+`Pack` has become a private constructor, only constructed through one of the static constructors `#readMetaAndCreate`, which acts similarly to the 1.19.2 `#create`, or `#create`. A common case that this will encounter is for the `AddPackFindersEvent`. Here are the list of changes:
+
+- `Supplier<PackResources>` has turned into `Pack$ResourcesSupplier` which takes in the pack id.
+- `PackType` is now a parameter to check whether the pack is compatible for the current version.
+- The description, feature flags, and hidden check is stored on the `Pack$Info`, which is either obtained from the metadata file or constructed from the record.
+
+## Data Generators
+
+Data Generators have changed quite a bit from how providers are added to the providers themselves.
+
+Starting off, all providers now take in a `PackOutput` compared to the `DataGenerator` itself. The `PackOutput` simply specifies the directory where the pack will be generated. Because of this change, the `#addProvider` method now takes in either the provider instance or a function that takes in a `PackOutput` and constructs a `DataProvider`.
+
+```java
+// On the mod event bus
+@SubscribeEvent
+public void gatherData(GatherDataEvent event) {
+  event.addProvider(true, output -> /*create provider here*/);
+}
+```
+
+### The Lookup Provider
+
+`GatherDataEvent` now provides a `CompletableFuture` containing a `HolderLookup$Provider`, which is used to get registries and their objects. This can be obtained via `#getLookupProvider`.
+
+### TagsProvider and IntrinsicHolderTagsProvider
+
+Forge adds a tag provider for `Block`s. Any others need to specify the function.
+
+```java
+// Subtype of `IntrinsicHolderTagsProvider`
+public AttributeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries, ExistingFileHelper fileHelper) {
+  super(
+    output,
+    ForgeRegistries.Keys.ATTRIBUTES,
+    registries,
+    attribute -> ForgeRegistries.ATTRIBUTES.getResourceKey(attribute).get(),
+    MOD_ID,
+    fileHelper
+  );
+}
+```
+
+### AdvancementProvider
+
+ For ease of access to the `ExistingFileHelper`, Forge has added an extension on the provider aptly named `ForgeAdvancementProvider` which takes in `ForgeAdvancementProvider$AdvancementGenerator`s which contain the `ExistingFileHelper` as a parameter.
+
+```java
+// On the MOD event bus
+@SubscribeEvent
+public void gatherData(GatherDataEvent event) {
+  event.getGenerator().addProvider(
+    // Tell generator to run only when server data are generating
+    event.includeServer(),
+    output -> new ForgeAdvancementProvider(
+      output,
+      event.getLookupProvider(),
+      event.getExistingFileHelper(),
+      // Sub providers which generate the advancements
+      List.of(subProvider1, subProvider2, /*...*/)
+    )
+  );
+}
+```
+
+The `ForgeAdvancementProvider$AdvancementGenerator` is responsible for generating advancements. To be able to effectively generate advancements the `ExistingFileHelper` should be passed in such that the advancement can be built using the `Advancement$Builder#save` method which takes it in.
+
+```java
+// In some ForgeAdvancementProvider$AdvancementGenerator or as a lambda reference
+
+@Override
+public void generate(HolderLookup.Provider registries, Consumer<Advancement> writer, ExistingFileHelper existingFileHelper) {
+  // Build advancements here
+}
+```
+
+### LootTableProvider
+
+`LootTableProvider` has received a massive overhaul, no longer needing to subtype the class and instead just supply arguments to the constructor. In addition to the `PackOutput`, it takes in a set of table names to validate whether they have been created and a list of `SubProviderEntry`s, which are used to generate the tables for each `LootContextParamSet`.
+
+```java
+// On the MOD event bus
+@SubscribeEvent
+public void gatherData(GatherDataEvent event) {
+  event.getGenerator().addProvider(
+    // Tell generator to run only when server data are generating
+    event.includeServer(),
+    output -> new MyLootTableProvider(
+      output,
+      // Specify registry names of tables that are required to generate, or can leave empty
+      Collections.emptySet(),
+      // Sub providers which generate the loot
+      List.of(subProvider1, subProvider2, /*...*/)
+    )
+  );
+}
+```
+
+### DatapackBuiltinEntriesProvider and the removal of JsonCodecProvider#forDatapackRegistry
+
+`JsonCodecProvider#forDatapackRegistry` was removed in favor of using the vanilla `RegistriesDatapackGenerator` for generating dynamic registry objects. To expand upon this provider, Forge introduced the `DatapackBuiltinEntriesProvider`, which can take in a `RegistrySetBuilder` to generate the specific dynamic objects to use, and a set of mod ids to determine which mod's dynamic registry objects to generate.
+
+```java
+// On the MOD event bus
+@SubscribeEvent
+public void gatherData(GatherDataEvent event) {
+  event.getGenerator().addProvider(
+    // Tell generator to run only when server data are generating
+    event.includeServer(),
+    output -> new DatapackBuiltinEntriesProvider(
+      output,
+      event.getLookupProvider(),
+      // The objects to generate
+      new RegistrySetBuilder()
+        .add(Registries.NOISE_SETTINGS, context -> {
+          // Generate noise generator settings
+          context.register(
+            ResourceKey.create(Registries.NOISE_SETTINGS, new ResourceLocation(MOD_ID, "example_settings")),
+            NoiseGeneratorSettings.floatingIslands(context)
+          );
+        }),
+      // Generate dynamic registry objects for this mod
+      Set.of(MOD_ID)
+    )
+  );
+}
+```
+
+## Resolving nested models
+
+To resolve models that are nested within other models, `IUnbakedGeometry#resolveParents` was added. This is a defaulted method, so no issues should occur in custom loaders; however, those who are resolving models within models will need to pivot to use this new method.
+
+## ModelEvent$ModifyBakingResult
+
+`ModelEvent$ModifyBakingResult` is an event fired on the **mod** event bus used to handle the caching of state -> model map done previously in `ModelEvent$BakingCompleted`. The usecases typically stem from users who need to make adjustments to models due to cases where custom loaders are not possible or that the context provided is insufficient.
+
+Due to the event being fired on a worker thread, you should only access those objects provided by the event itself as it is otherwise unsafe.
+
+## Entity#getAddEntityPacket no longer abstract
+
+`Entity#getAddEntityPacket` is no longer abstract, instead defaulting to the `ClientboundAddEntityPacket`. If you need to send additional data on entity creation, you should still use `NetworkHooks#getEntitySpawningPacket`.
+
+## Minor Refactors
+
+- `net.minecraft.data.tags.BlockTagsProvider` -> `net.minecraftforge.common.data.BlockTagsProvider`

--- a/primers/1.19.3/forge.md
+++ b/primers/1.19.3/forge.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Vanilla Changes
 

--- a/primers/1.19.3/index.md
+++ b/primers/1.19.3/index.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Feature Flags
 

--- a/primers/1.19.3/index.md
+++ b/primers/1.19.3/index.md
@@ -1,0 +1,326 @@
+# Minecraft 1.19.2 -> 1.19.3 Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.19.2 to 1.19.3 using. This does not look at any specific mod loader, just the changes to the vanilla classes.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Feature Flags
+
+Feature Flags are a behavior/logic toggle for blocks and items. They determine whether certain actions or generations related to the object can trigger (e.g. bamboo boats can only be placed when the `minecraft:update_1_20` flag is enabled).
+
+Vanilla currently provides three flags as of this version (via `FeatureFlags`):
+- `minecraft:vanilla`: For everything in vanilla minecraft
+- `minecraft:bundle`: For the bundle feature pack and in the creative tab
+- `minecraft:update_1_20`: For objects related to the upcoming 1.20 release
+
+You can force an item or block to require one of these features by adding it as a property via `#requiredFeatures`. This will affect all behavior and logic associated with the object. 
+
+```java
+// In some supplied instance
+new Block(BlockBehaviour.Properties.of(/*...*/).requiredFeatures(/*features here*/));
+
+new Item(new Item.Properties().requiredFeatures(/*features here*/));
+```
+
+If you only want to affect some behavior or logic associated with the object, then you will need to check `FeatureFlagSet#contains` yourself on whatever system you are using.
+
+> Do not add your own `FeatureFlag`s. Currently, they are limited to only 6 and are hardcoded to vanilla's highly-specific implementation.
+
+## Registries
+
+Registries have received a significant overhaul, resulting in better stability.
+
+### No In-Code Entries in Dynamic Registries
+
+Dynamic registries such as dimension types or features can no longer be declared in-code. Instead, a JSON of each must now be provided.
+
+### Key and Registry Locations
+
+The locations of the registry keys and the registries themselves have moved. Registry keys are now in `net.minecraft.core.registries.Registries`. Static registries are now in `net.minecraft.core.registries.BuiltInRegistries`.
+
+Dynamic registries can only be obtained from the `RegistryAccess` from the `MinecraftServer`. There is no more static access to it, such as using `RegistryAccess#builtinCopy`.
+
+### Registry Order
+
+The registry order has changed as well due to a bunch of stability fixes. This should not matter in most cases if you want to support registry replacement as a `Supplier` of the value is necessary, but this will be noted down regardless. This is the current order in which registries load:
+
+- `minecraft:sound_event`
+- `minecraft:fluid`
+- `minecraft:block`
+- `minecraft:attribute`
+- `minecraft:mob_effect`
+- `minecraft:particle_type`
+- `minecraft:item`
+- `minecraft:entity_type`
+- `minecraft:sensor_type`
+- `minecraft:memory_module_type`
+- `minecraft:potion`
+- `minecraft:game_event`
+- `minecraft:enchantment`
+- `minecraft:block_entity_type`
+- `minecraft:painting_variant`
+- `minecraft:stat_type`
+- `minecraft:custom_stat`
+- `minecraft:chunk_status`
+- `minecraft:rule_test`
+- `minecraft:pos_rule_test`
+- `minecraft:menu`
+- `minecraft:recipe_type`
+- `minecraft:recipe_serializer`
+- `minecraft:position_source_type`
+- `minecraft:command_argument_type`
+- `minecraft:villager_type`
+- `minecraft:villager_profession`
+- `minecraft:point_of_interest_type`
+- `minecraft:schedule`
+- `minecraft:activity`
+- `minecraft:loot_pool_entry_type`
+- `minecraft:loot_function_type`
+- `minecraft:loot_condition_type`
+- `minecraft:loot_number_provider_type`
+- `minecraft:loot_nbt_provider_type`
+- `minecraft:loot_score_provider_type`
+- `minecraft:float_provider_type`
+- `minecraft:int_provider_type`
+- `minecraft:height_provider_type`
+- `minecraft:block_predicate_type`
+- `minecraft:worldgen/carver`
+- `minecraft:worldgen/feature`
+- `minecraft:worldgen/structure_processor`
+- `minecraft:worldgen/structure_placement`
+- `minecraft:worldgen/structure_piece`
+- `minecraft:worldgen/structure_type`
+- `minecraft:worldgen/placement_modifier_type`
+- `minecraft:worldgen/block_state_provider_type`
+- `minecraft:worldgen/foliage_placer_type`
+- `minecraft:worldgen/trunk_placer_type`
+- `minecraft:worldgen/root_placer_type`
+- `minecraft:worldgen/tree_decorator_type`
+- `minecraft:worldgen/feature_size_type`
+- `minecraft:worldgen/biome_source`
+- `minecraft:worldgen/chunk_generator`
+- `minecraft:worldgen/material_condition`
+- `minecraft:worldgen/material_rule`
+- `minecraft:worldgen/density_function_type`
+- `minecraft:worldgen/structure_pool_element`
+- `minecraft:cat_variant`
+- `minecraft:frog_variant`
+- `minecraft:banner_pattern`
+- `minecraft:instrument`
+- `minecraft:worldgen/biome`
+
+## Existing Creative Tabs
+
+`CreativeModeTab`s are no longer set through a property on the item; they are harcoded onto the creative tab itself.
+
+## The JOML Library
+
+Mojang has migrated from using their own math classes for rendering to using [JOML](https://github.com/JOML-CI/JOML), a open source math library for OpenGL. You can fix most of these issues by changing the package of the vector, matrix, etc. to `org.joml`; however it is not a 1 to 1 translation. Some changes are functional: `Matrix*` methods modify a mutable instance instead of creating a new one, or `Quaternionf` using `AxisAngle*` instead of `Vector3f`.
+
+## SoundEvent
+
+`SoundEvent`s have slightly changed in this version. Specifically, they are constructed through a static method constructor which introduces a new system: fixed range sound. The standard `SoundEvent` from previous versions can be constructed using `SoundEvent#createVariableRangeEvent`, whose range changes depending on the volume of the sound with a minimum of 16 blocks. Sounds constructed from `SoundEvent#createFixedRangeEvent` can be heard from the range specified, regardless of the volume.
+
+```java
+// In some supplied instance
+
+// Will change depending on volume, minimum 16 blocks
+SoundEvent.createVariableRangeEvent("sound.example_mod.variable_example");
+
+// Will only be heard within specified range (e.g. 5 blocks)
+SoundEvent.createFixedRangeEvent("sound.example_mod.fixed_example", 5f);
+```
+
+## Packs and PackResources
+
+`Pack`s and `PackResources` have changed slightly between the two versions.
+
+First `PackResources#hasResource` no longer exists. Instead `#getResource` should be checked for nullability instead before getting the `InputStream` from the `IoSupplier`.
+
+```java
+// Given some PackResources resources
+var io = resources.getResource(PackType.SERVER_DATA, new ResourceLocation(/**/));
+
+if (io != null) {
+  InputStream input = io.get();
+  // Same as before
+}
+```
+
+Additionally, `#getResources` has been replaced by `#listResources` with the `ResourceLocation` predicate changing to a `PackResources$ResourceOutput` which acts as a consumer taking in the resource and the `IoSupplier` the resource would be located in.
+
+Finally, `Pack` has become a private constructor, only constructed through one of the static constructors `#readMetaAndCreate`, which acts similarly to the 1.19.2 `#create`, or `#create`.
+
+## Data Generators
+
+Data Generators have changed quite a bit from how providers are added to the providers themselves.
+
+Starting off, all providers now take in a `PackOutput` compared to the `DataGenerator` itself. The `PackOutput` simply specifies the directory where the pack will be generated. Because of this change, the `#addProvider` method now takes in a function that takes in a `PackOutput` and constructs a `DataProvider`.
+
+### Data Providers and CompleteableFutures
+
+All `DataProvider`s now return a `CompletableFuture` on `#run`, which is used to write the data to its apropriate file.
+
+### RecipeProvider and RecipeCategory
+
+`RecipeProvider`s now construct recipes in `#buildRecipes`. Additionally, each recipe builder, besides dynamic recipes, must specify a `RecipeCategory` which determines the subdirectory on where the recipe will be generated.
+
+```java
+// In RecipeProvider#buildRecipes(writer)
+ShapedRecipeBuilder builder = ShapedRecipeBuilder.shaped(RecipeCategory.MISC, result)
+  .pattern("a a") // Create recipe pattern
+  .define('a', item) // Define what the symbol represents
+  .unlockedBy("criteria", criteria) // How the recipe is unlocked
+  .save(writer); // Add data to builder
+```
+
+### TagsProvider and IntrinsicHolderTagsProvider
+
+`TagsProvider`s can only add objects through their `ResourceKey`. To add objects directly, an `IntrinsicHolderTagsProvider` should be used instead. This takes in a function which extracts a key from the object itself. Vanilla creates these for `Item`s, `EntityType`s, `Fluid`s, and `GameEvent`s. Any others need to specify the function.
+
+```java
+// Subtype of `IntrinsicHolderTagsProvider`
+public AttributeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+  super(
+    output,
+    Registries.ATTRIBUTE,
+    registries,
+    attribute -> BuiltInRegistries.ATTRIBUTE.getResourceKey(attribute).get()
+  );
+}
+```
+
+### LootTableProvider
+
+`LootTableProvider` has received a massive overhaul, no longer needing to subtype the class and instead just supply arguments to the constructor. In addition to the `PackOutput`, it takes in a set of table names to validate whether they have been created and a list of `SubProviderEntry`s, which are used to generate the tables for each `LootContextParamSet`.
+
+A `LootTableSubProvider` is used to generate the loot tables in the `SubProviderEntry`, essentially functioning the same as a `Supplier<Consumer<BiConsumer<ResourceLocation, LootTable.Builder>>>`.
+
+```java
+public class ExampleSubProvider implements LootTableSubProvider {
+
+  // Used to create a factory method for the wrapping Supplier
+  public ExampleSubProvider() {}
+
+  // The method used to generate the loot tables
+  @Override
+  public void generate(BiConsumer<ResourceLocation, LootTable.Builder> writer) {
+    // Generate loot tables here by calling writer#accept
+  }
+}
+
+// In the list passed into the LootTableProvider constructor
+new LootTableProvider.SubProviderEntry(
+  ExampleSubProvider::new,
+  // Loot table generator for the 'empty' param set
+  LootContextParamSets.EMPTY
+)
+```
+
+The overrides for blocks and entities still exist being called `BlockLootSubProvider` and `EntityLootSubProvider` respectively. They both take in the feature flags, with the block sub provider taking in a set of items to which are resistant to explosions. The method used to generate the tables have been changed from `#addTables` to `#generate`. You still need to override the `#getKnown*` methods for validation.
+
+```java
+// In some BlockLootSubProvider subclass
+public MyBlockLootSubProvider() {
+  super(Collections.emptySet(), FeatureFlags.REGISTRY.allFlags());
+}
+
+@Override
+public void generate() {
+  // Add tables here
+}
+```
+
+### AdvancementProvider
+
+`AdvancementProvider` has also received a massive overhaul, no longer needing to subtype the class and instead just supply arguments to the constructor. In addition to the `PackOutput`, it takes in the holder lookup for registries and the `AdvancementSubProvider`s, which are used to generate the advancements.
+
+## Rendering Changes
+
+Rendering has changed a massive amount in this update. The most common being those explicitly mentioned by minecraft such as item and block textures only being in `models/item` and `models/block` respectively or the asynchronous loading and writing of assets and data. Textures for items and blocks are also required to be in `textures/item` and `textures/block` respectively as textures are loaded before model are processed. These texture directories are specified in JSON in the `atlases` directory.
+
+This section will try to cover all the updates in 1.19.3 as these issues get fixed.
+
+## Behaviors by DataFixerUpper
+
+Behaviors are being migrated to use a new system built around the abstractions and overengineering provided by DataFixerUpper (DFU). As these systems tend to be complex and convoluted, this will only provide a brief overview of the changes and implementations.
+
+### BehaviorControl
+
+The `Behavior` class is no longer the base for behavior logic. That has been relegated to `BehaviorControl`: an interface which `Behavior` implements. `BehaviorControl` checks whether the logic can start (`#tryStart`), its ticking and stop check (`#tickOrStop`), and finally the stop logic (`#doStop`).
+
+Some classes affected by this are `DoNothing` and `GateBehavior` which implements `BehaviorControl`.
+
+### OneShot
+
+`OneShot` is a behavior control which executes once via a `Trigger` statement. If the `Trigger#trigger` returns true, the behavior control is executed; though it only sets the state to running for a single tick.
+
+### BehaviorBuilder and TriggerGate
+
+BehaviorBuilder and TriggerGate are essentially the DFU-implemented classes which creates `OneShot` triggers such as waking up or strolling to a point of interest.
+
+For a basic understanding, a `BehaviorBuilder` acts similarly to a `RecordCodecBuilder`: it creates the behavior instance, takes in the necessary `MemoryModuleType`s and whether it is registered, present, or absent, and then applies to construct a `Trigger`. The `BehaviorBuilder` also contains methods to make triggers act sequentially or if a given predicate is met.
+
+`TriggerGate` is an holder of state methods for `GateBehavior`s. It either triggers a single instance at random (`#triggerOneShuffled`) or executed based on the ordering and run policy selected (`#triggerGate`).
+
+## Minor Changes
+
+This is a list of minor changes which probably won't affect the modding experience but is convenient to know anyways.
+
+### Entity#getAddEntityPacket no longer abstract
+
+`Entity#getAddEntityPacket` is no longer abstract, instead defaulting to the `ClientboundAddEntityPacket`.
+
+### AbstractContainerMenu#stillValid Static Method
+
+`AbstractContainerMenu` has now migrated from using the `Container` to check whether the menu could still be kept open to using a static method called `#stillValid` in the instance of the same name. To use this method, you need to provide a `ContainerLevelAccess`, the player, and the `Block` the menu is attached to.
+
+```java
+// Client menu constructor
+public MyMenuAccess(int containerId, Inventory playerInventory) {
+  this(containerId, playerInventory, ContainerLevelAccess.NULL);
+}
+
+// Server menu constructor
+public MyMenuAccess(int containerId, Inventory playerInventory, ContainerLevelAccess access) {
+  // ...
+}
+
+// Assume this menu is attached to RegistryObject<Block> MY_BLOCK
+@Override
+public boolean stillValid(Player player) {
+  return AbstractContainerMenu.stillValid(this.access, player, MY_BLOCK.get());
+}
+```
+
+### BlockStateProvider#simpleBlockWithItem
+
+The `BlockStateProvider` now contains a new method to generate a simple block state for a single block model along with an associated item model.
+
+```java
+// In some BlockStateProvider#registerStatesAndModels
+// Assume there is a RegistryObject<Block> BLOCK
+this.simpleBlockWithItem(BLOCK.get(), this.cubeAll(BLOCK.get()));
+```
+
+### Removal of Context-Sensitive Tree Growers
+
+The context-sensitive methods within `AbstractMegaTreeGrower` and `AbstractTreeGrower` have been removed and as such no longer have access to the world or position as the methods now return the keys of the `ConfiguredFeature` rather than the feature itself.
+
+### Music, now with Holders
+
+The `Music` class, used to provide a background track during different situations, now takes in a `Holder<SoundEvent>` rather than the `SoundEvent` itself.
+
+### KeyboardHandler#sendRepeatsToGui removed
+
+Minecraft has removed `KeyboardHandler#sendRepeatsToGui` when a key was held down such that it repeated within a GUI. There is no replacement, so the handler will now always send repeats to the GUI.
+
+## Renames and Refactors
+
+The following classes were renamed or refactored within Minecraft:
+
+- `net.minecraft.client.gui.components.Widget` -> `net.minecraft.client.gui.components.Renderable`
+- `net.minecraft.data.loot.BlockLoot` -> `net.minecraft.data.loot.BlockLootSubProvider`
+- `net.minecraft.data.loot.EntityLoot` -> `net.minecraft.data.loot.EntityLootSubProvider`

--- a/primers/1.19.4/forge.md
+++ b/primers/1.19.4/forge.md
@@ -1,0 +1,58 @@
+# Minecraft 1.19.3 -> 1.19.4 Forge Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.19.3 to 1.19.4 using Forge.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Vanilla Changes
+
+Vanilla changes are listed [here](./index.md).
+
+## Creative Tabs
+
+Custom creative tabs from the previous primer are now slightly modified to take in the two parameters: 
+
+```java
+// Registered on the MOD event bus
+// Assume we have RegistryObject<Item> and RegistryObject<Block> called ITEM and BLOCK
+@SubscribeEvent
+public void buildContents(CreativeModeTabEvent.Register event) {
+  event.registerCreativeModeTab(new ResourceLocation(MOD_ID, "example"), builder ->
+    // Set name of tab to display
+    builder.title(Component.translatable("item_group." + MOD_ID + ".example"))
+    // Set icon of creative tab
+    .icon(() -> new ItemStack(ITEM.get()))
+    // Add default items to tab
+    .displayItems((params, output) -> {
+      output.accept(ITEM.get());
+      output.accept(BLOCK.get());
+    })
+  );
+}
+```
+
+Additionally, `net.minecraftforge.event.CreativeModeTabEvent$BuildContents` can access the parameters via `#getParameters`. The other methods now delegate to the parameters for better compatibility when updating from 1.19.3.
+
+## Spawn Events Refactor
+
+As of 45.0.23, spawn events have been completely refactored. For starters, `LivingSpawnEvent` has been renamed to `MobSpawnEvent`. Even further `CheckSpawn` and `SpecialSpawn` hae been merged into a single event: `FinalizeSpawn`. `FinalizeSpawn` can be canceled to prevent `Mob#finalizeSpawn` from being called while the entity itself can be prevent using` FinalizeSpawn#setSpawnCancelled`.
+
+If you want to learn more about this event and the technical changes, see the [blog post](https://blog.minecraftforge.net/breaking/spawnevents/).
+
+## New Registries
+
+Forge has added a new static registry for `ItemDisplayContext`s aptly named `forge:display_contexts` for registering perspectives an item may be rendered within, replacing custom `TransformType`s. There can only be at most 256 display contexts.
+
+## Sprite Registration Refactoring
+
+As of 45.0.25, all `net.minecraftforge.client.event.RegisterParticleProvidersEvent#register` methods have been deprecated for removal, opting to switch to method names which better specify their usecase:
+
+* `#register(ParticleType, ParticleProvider)` -> `#registerSpecial`
+* `#register(ParticleType, ParticleProvider$Sprite)` -> `#registerSprite`
+* `#register(ParticleType, ParticleEngine$SpriteParticleRegistration)` -> `#registerSpriteSet`
+
+## Minor Changes
+
+* `net.minecraftforge.fml.CrashReportCallables` can now be supplied a callable which will append to the system report when the boolean supplier returns `true`.

--- a/primers/1.19.4/forge.md
+++ b/primers/1.19.4/forge.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Vanilla Changes
 

--- a/primers/1.19.4/index.md
+++ b/primers/1.19.4/index.md
@@ -1,0 +1,188 @@
+# Minecraft 1.19.3 -> 1.19.4 Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.19.3 to 1.19.4. This does not look at any specific mod loader, just the changes to the vanilla classes.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Pack Changes
+
+There are a number of user-facing changes that are part of vanilla which are not discussed below that may be relevant to modders. You can find a list of them on [Misode's version changelog](https://misode.github.io/versions/?id=1.19.4&tab=changelog).
+
+## DamgeType and DamageSources
+
+Damage sources have been rewritten to define common data which should be static between different sources. As such, each `DamageSource` now takes in a `DamageType` which defines this information. `DamageType`s are created in json like any other datapack registry.
+
+The main `DamageType` record constructor takes in the following arguments:
+
+Parameter        | Type               | Decsription
+:---:            | :---:              | :---
+msgId            | `String`           | A string used within a localization key (typically preceded by `death.attack.`).
+scaling          | `DamageScaling`    | When the damage caused by the type should scale according to difficulty.
+exhaustion       | `float`            | How much food exhaustion should occur when the damage source is applied to the player.
+effects          | `DamageEffects`    | The sound to be played when the type is applied to an entity.
+deathMessageType | `DeathMessageType` | How the death message should be structured for the type. Should almost always be `DEFAULT`.
+
+A `DamageSource` is now treated as final class (it's not actually final, so it can still be extended if needed) which takes in some combination of the following parameters:
+
+Parameter            | Type                 | Decsription
+:---:                | :---:                | :---
+type                 | `Holder<DamageType>` | The damage type, typically obtained from the `RegistryAccess`.
+causingEntity        | `Entity`             | The entity who caused the damage directly or through the `#directEntity`.
+directEntity         | `Entity`             | The entity who directly inflicted the damage.
+damageSourcePosition | `Vec3`               | The position the damage source took place.
+
+The damage sources are now constructed in `DamageSources` which can be obtained from the `Level` via `#damageSources`. Every `Entity` also has a redirect method to the level via `#damageSources`.
+
+### DamageSourcePredicate
+
+The `DamageSourcePredicate` for criteria triggers has been rewritten to take in a list of `TagPredicate`s for the `DamageType` applied along with the direct and causing (source) entity.
+
+> `TagPredicate`s check if the specific object is either within or not within a tag (triggered by the `expected` boolean flag).
+
+## GUI Changes
+
+There have been a number of GUI changes which expands upon existing methods, restructures components, and reorganizes their locations.
+
+### GuiComponent
+
+All `GuiComponent` methods are now static. Additionally, new methods were added to draw information to the screen: `#renderOutline` and `#blitNineSliced`. `#setBlitOffset` and `#getBlitOffset` have been removed and are now performed using the `PoseStack` by translating the z-axis.
+
+### ScreenRectangle
+
+A new class called `ScreenRectangle` to specify a rectangle. This is typically used for scissors and layouts; however, it could also be used in standard rendering.
+
+### ComponentPath
+
+Logic relating to how components are focused and executed are now handled through `ComponentPath`s which now handle the responsibility of a for loop on a list.
+
+### More PoseStack additions
+
+The `PoseStack` has been added to a number of methods to properly transform the drawn information onto the screen space.
+
+### Widget Restructing
+
+A number of widgets have been restructured or moved into different classes to handle some common logic.
+
+The following components have been added:
+* `net.minecraft.client.gui.components.TabButton` and by extension `net.minecraft.client.gui.components.tabs.TabNavigationBar`
+* `net.minecraft.client.gui.components.AbstractStringWidget` and by extension `net.minecraft.client.gui.components.MultiLineTextWidget`
+* `net.minecraft.client.gui.components.ImageWidget`
+* `net.minecraft.client.gui.components.TextAndImageButton`
+
+In addition, the following components were moved, renamed, or modified:
+* `net.minecraft.client.gui.components.CenteredStringWidget` -> `net.minecraft.client.gui.components.StringWidget`
+* `net.minecraft.client.gui.components.AbstractWidget#renderButton` -> `#renderWidget`
+* `net.minecraft.client.gui.components.AbstractWidget#getYImage` reworked into `AbstractButton#getTextureY` where it returns the texture coordinate rather than the texture index
+
+#### Layout Components
+
+Layout components, such as the `FrameWidget`, within `net.minecraft.client.gui.components` have been moved to `net.minecraft.client.gui.layouts`. Additionally, they have been restructure to consume widgets to properly move them to where they need to be displayed rather than having each layout be its own widget. As such, `AbstractContainerWidget` was removed.
+
+### Font DisplayMode
+
+`Font#drawInBatch` and any subsequent delegates (e.g. `FontRenderer#drawInBatch`) now take in a `Font$DisplayMode` instead of a boolean to determine how the font should be displayed. 
+
+## Entity Interfaces
+
+Entity logic has been abstracted even more into three new interfaces: `Attackable`, `Targeting`, and `TraceableEntity`. The `Attackable` interface indicates the entity can be attacked and stores the last attacker via `#getLastAttacker`. The `Targeting` interface indicates the entity can target another entity and stores the value via `#getTarget`. Finally, the `TraceableEntity` interface means that the entity's creation and initial action can be traced back to another entity, which can be obtained via `#getOwner`.
+
+> `TraceableEntity` should not be confused with `OwnableEntity`. Traceables are typically used for projectiles or entities fired from or triggered by another entity while ownables are typically for tamed animals.
+
+## Blocks and Sounds
+
+Blocks have a few changes regarding their internal implementation and data structures.
+
+The `BlockBehaviour$OffsetType` passed into `BlockBehavior$Properties#offsetType` now redirects to `BlockBehavior$OffsetFunction` which takes in a `BlockState`, `BlockGetter`, and `BlockPos` and returns the amount to offset the model by. This is currently not exposed to the end user.
+
+A new record has been made to store common properties associated with a type, aptly named `BlockSetType`. This takes in the `SoundType` for the block in addition to sound events for flicking on or off a door, trapdoor, pressure plate, and button. Following this trend, `WoodType`s now take in the `BlockSetType` in addition to `SoundType`s for the wood and hanging sign along with `SoundEvent`s for the fence gate. `WoodType`s are also registered via the `#register` method instead of `#create`:
+
+```java
+public static final WoodType TEST_WOOD_TYPE = WoodType.register(new WoodType(new ResourceLocation(MODID, "test").toString(), BlockSetType.ACACIA));
+```
+
+> `BlockSetType`s can be created and registered using the constructor and `BlockSetType#register`, repsectively, after the `SoundEvent` registry event has fired but before the `Block` registry event.
+
+## Creative Tabs
+
+Creative Tabs have slightly changed as now when populating the generator, the method provides `CreativeModeTab$ItemDisplayParameters` and an `CreativeModeTab$Output`. The parameters holds the list of enabled feature, whether the player has permission, and a lookup provider on all the registries.
+
+## Removal of `com.mojang.bridge.*`
+
+Mojang's `javabridge` library has been removed as a dependency from Minecraft. As such, all of the redirected counterparts to the bridge (such as `com.mojang.bridge.game.PackType` and `com.mojang.bridge.game.GameVersion`) are now handled by their references or implementations (`net.minecraft.server.packs.PackType` and `net.minecraft.WorldVersion` respectively).
+
+## Minor Additions, Changes, and Removals
+
+The following is a list of useful or interesting additions, changes, and removals that do not deserve their own section in the primer.
+
+### New Registries
+
+In addition to `DamageType`s, a static registry for decorated pot patterns and datapack registries for trim materials, trim patterns, and `MultiNoiseBiomeSourceParameterList` have been added.
+
+### New Codecs
+
+A number of new codecs have been added or changed:
+  * `com.mojang.math.Transformation#CODEC`
+  * `net.minecraft.util.ExtraCodecs#QUATERNIONF_COMPONENTS`
+  * `net.minecraft.util.ExtraCodecs#AXISANGLE4F`
+  * `net.minecraft.util.ExtraCodecs#MATRIX4F`
+
+### Sprite Registration Refactoring
+
+First, `net.minecraft.client.particle.ParticleProvider$Sprite` is added, which is a functional interface used to create a `TextureSheetParticle` with only one texture. This is used as a wrapper around a `ParticleEngine$SpriteParticleRegistration` when the particle does not need access to the `SpriteSet`.
+
+### Additions
+
+* `GlintAlpha` - A new GLSL shader uniform which changes the glint strength based on the accessibility option of a similar name.
+* `net.minecraft.advancements.Advancement#getRoot` - Gets the root of an advancement.
+* `net.minecraft.client.model.geom.builders.CubeListBuilder#addBox` can now take in a set of directions which indicates the visible faces to render of a given box. This is baked into the `net.minecraft.client.model.geom.ModelPart$Cube` when adding the polygons.
+* `net.minecraft.client.model.AgeableHierarchicalModel` - A parallel to `net.minecraft.client.modelAgeableListModel`s for `HierarchialModel`s.
+* `net.minecraft.client.model.HumanoidArmorModel` - An extension of `net.minecraft.client.model.HumanoidModel` for armor models.
+* `com.mojang.blaze3d.vertex.PoseStack#rotateAround` - Rotates a quaternion around a point.
+* `net.minecraft.commands.arguments.HeightmapTypeArgument` - A common argument for specifying which heightmap to use.
+* `net.minecraft.gametest.framework.GameTestHelper#continuouslyUse` - A helper test method to force a player to use an item on a certain block position every tick.
+* `net.minecraft.util.ParticleUtils#spawnParticleBelow` - Spawns a particle half a block below the specified position
+* `net.minecraft.world.inventory.Slot#setByPlayer` - A method indicating that a player changed the slot in some capacity.
+* `net.minecraft.world.effect.MobEffectInstance#endsWithin` - Returns whether the mob effect will expire in x ticks.
+* `net.minecraft.world.entity.Entity#getControlledVehicle` - Returns the vehicle if it is being controlled by this entity.
+* `net.minecraft.world.phys.AABB#distanceToSqr` - Gets the squared distance to the provided vector.
+* `net.minecraft.world.phys.Vec3#atLowerCornerWithOffset` - Offsets the vector by the specified x, y, z coordinates.
+* `net.minecraft.world.phys.Vec3#atCenterOf` - Offsets the vector by 0.5 in all directions.
+* `net.minecraft.data.advancements.AdvancementSubProvider#createPlaceholder` - Creates a dummy advancement to use as a parent for another advancement.
+* `net.minecraft.network.FriendlyByteBuf#readJsonWithCodec` and #writeJsonWithCodec` - Writes a encoded object to json into a buffer.
+    * `Tag` implementations `#readWithCodec` and `#writeWithCodec` are currently deprecated.
+* `net.minecraft.client.renderer.texture.Dumpable` - Dumps the contents of the object to a file (`DynamicTexture`, `TextureAtlas`).
+* `net.minecraft.world.entity.LivingEntity#remove` - Removes the entity from the level for the specified reason.
+* `net.minecraft.world.entity.ai.Brain#clearMemories` - Clears all the memory values of an entity's brain.
+* `com.mojang.math.MatrixUtil` contains some additional [jacobi matrix](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant) methods.
+* `net.minecraft.world.level.GrassColor#getDefaultColor` - Gets the default color of grass.
+* `net.minecraft.network.syncher.SynchedEntityData#set(EntityDataAccessor, T, boolean)` - Boolean parameter added to force a sync of the entity data.
+
+### Changes
+
+* `net.minecraft.world.level.biome.Biome#isHumid` -> `#hasPrecipitation`
+* `net.minecraft.world.level.biome.Biome#getPrecipitation()` -> `#getPrecipitationAt(BlockPos)`
+* `net.minecraft.world.entity.LivingEntity#animationSpeedOld`, `#animationSpeed`, and `#animationPosition` has been bundled into one public object on the entity known as `WalkAnimationState`.
+* `net.minecraft.server.packs.repository.PackRepository#addPack` and `#removePack` now return a boolean on whether the action was successful.
+* `net.minecraft.client.gui.screens.worldselection.WorldGenSettingsComponent` -> `WorldCreationUiState`
+* `net.minecraft.client.renderer.block.model.ItemTransforms$TransformType` -> `net.minecraft.world.item.ItemDisplayContext`
+* `net.minecraft.client.resources.metadata.language.LanguageMetadataSectionSerializer` -> `LanguageMetadataSection#CODEC`
+* `net.minecraft.world.item.crafting.UpgradeRecipe` -> `LegacyUpgradeRecipe`
+    * Deprecated for removal; replaced by `SmithingRecipe`, `SmithingTransformRecipe`, and `SmithingTrimRecipe`
+* `net.minecraft.data.recipes.UpgradeRecipeBuilder` -> `LegacyUpgradeRecipeBuilder`
+    * Deprecated for removal; replaced by `SmithingTransformRecipeBuilder` and `SmithingTrimRecipeBuilder`
+* `net.minecraft.data.worldgen.biome.Biomes` -> `BiomeData`
+* `net.minecraft.world.item.Wearable` -> `Equipable`
+* `net.minecraft.world.item.crafting.Recipe#assemble(C)` and `#getResultItem()` -> `#assemble(C, RegistryAccess)` and `#getResultItem#(RegistryAccess)`
+* `net.minecraft.world.entity.Entity#rideableUnderWater` -> `#dismountsUnderwater`
+* `net.minecraft.world.entity.PlayerRideableJumping#canJump(Player)` -> `#canJump()`
+* `net.minecraft.data.tags.TagsProvider` now can take in a `CompletableFuture<TagsProvider.TagLookup<T>>` if tags need to be accessed from other `TagProvider`s. A lookup can be obtained via `TagsProvider#contentsGetter`.
+* `net.minecraft.world.item.ArmorItem` now take in a delegate to the `EquipmentSlot` called `ArmorItem$Type` within their constructors and associated references.
+* `net.minecraft.core.BlockPos` constructors that take in doubles should migrate to using `BlockPos#containing`.
+* `net.minecraft.world.level.biome.MobSpawnSettings$SpawnerData#minCount` and `#maxCount` must be positive values.
+
+### Removals
+
+* `net.minecraft.world.level.biome.Biome#hasDownfall` as it was only used by the `#isHumid` check, now `#hasPrecipitation`.
+* `com.mojang.blaze3d.systems.RenderSystem#enableTexture` and `#disableTexture` as they have not been doing anything other than adding extra cycles to the logic execution.

--- a/primers/1.19.4/index.md
+++ b/primers/1.19.4/index.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Pack Changes
 

--- a/primers/1.20.5/index.md
+++ b/primers/1.20.5/index.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Pack Changes
 

--- a/primers/1.20.5/index.md
+++ b/primers/1.20.5/index.md
@@ -1,0 +1,1155 @@
+# Minecraft 1.20.4 -> 1.20.5 Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.20.4 to 1.20.5. This does not look at any specific mod loader, just the changes to the vanilla classes.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Pack Changes
+
+There are a number of user-facing changes that are part of vanilla which are not discussed below that may be relevant to modders. You can find a list of them on [Misode's version changelog](https://misode.github.io/versions/?id=1.20.5&tab=changelog).
+
+## Java 21
+
+Minecraft now uses Java 21. You can download a copy of the JDK used here: https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-21
+
+Windows machines can install this using `winget` in PowerShell:
+
+```pwsh
+winget install Microsoft.OpenJDK.21
+```
+
+## Data Components
+
+Data components (held within a `DataComponentMap`) are a replacement to the `CompoundTag` within an `ItemStack`. Each data component represents a key-value pair where the key is a string and the value is an object holding the data. Data components can be written to disk or synchronized across the network using codecs. All of vanilla's data components are stored within `DataComponents`, where arbitrary data that hasn't been converted to a data component is held within the `minecraft:custom_data` key.
+
+The storage of data components has an analog to Maps, where `DataComponentMap` represents a read-only map and its implementation `PatchedDataComponentMap` represents an identity map. The data component values themselves should always be treated as **immutable** objects as both the hash code and equality are determined based on both the keys and values.
+
+To hold data components, an object must implement `DataComponentHolder`. Currently this is only implement by `ItemStack`. The holder itself does not have any write based methods. `ItemStack`, on the other hand, does have methods to `set`, `update`, and `remove` attached components. Any operations that wish to modify a component's value should call `set` or `update`, making sure that the component value is **immutable** or at least not shallowly referenced somewhere else. Each method takes in a `DataComponentType` which represents the key of the value and the type of object being stored.
+
+```java
+// For some ItemStack 'stack' that wants a custom name
+stack.set(DataComponents.CUSTOM_NAME, Component.literal("Hello world!"));
+
+// To get the custom name
+Component name = stack.get(DataComponents.CUSTOM_NAME);
+
+// To update the stored value of the component
+stack.update(DataComponents.CUSTOM_NAME, Component.literal("Default if not set"), component ->
+  component.withStyle(ChatFormatting.BLUE)
+);
+
+// To remove the component
+stack.remove(DataComponents.CUSTOM_NAME);
+```
+
+To create a custom data component, you must register a `DataComponentType`. These can be constructed via `DataComponentType$Builder`. The builder has two methods: `persistent(Codec)` for if you want the data component to be written to disk, and `networkSynchronized(StreamCodec)` for if you want the data component to be synchronized to the client. `StreamCodec`s are explained in more detail in the next section. The component type can also cache the currently encoded value if you are writing to disk the same value often via `cacheEncoding`. 
+
+As an additional utility, `Item`s can have a default set of data components via `Item$Properties#component`. These values can then be updated for each individual stack.
+
+Any methods regarding items that took in a `CompoundTag` are will now take in the direct object type. The list of available data component objects can be found within `net.minecraft.world.item.component`.
+
+## Stream Codecs
+
+When communicating across a network, previously, all logic needed to be manually written and read to a `FriendlyByteBuf`. However, most of this logic has now been replaced with `StreamCodec`s. A `StreamCodec` is a type of codec (which doesn't implement `Codec`) that holds a function to apply stream-based operations to encode and decode a given object. A `StreamCodec` is made up of two parts: the `StreamEncoder` and `StreamDecoder`.
+
+The `StreamEncoder` takes in two generics, `O` representing the output to write data to, and `T` representing the data object. The `StreamDecoder` also takes in two generics, `I` representing the input to read data from, and `T` representing the constructed data object.
+
+To create a `StreamCodec`, you will usually use one of the `composite` functions. The `composite` function takes in up to 6 pairs of `StreamCodec` containing the type to serialize and `Function`s representing the getter for the data field. The final parameter represents the constructor for the object. There are a set of default stream codecs located in `ByteBufCodecs`.
+
+```java
+// A basic stream codec for a record ExampleObject(int, Optional<String>, Holder<Item>)
+
+// Using RegistryFriendlyByteBuf as a registry object is requested
+// Otherwise, FriendlyByteBuf should be used
+// If no special methods from FriendlyByteBuf are needed, use ByteBuf
+public static final StreamCodec<RegistryFriendlyByteBuf, ExampleObject> STREAM_CODEC = StreamCodec.composite(
+  ByteBufCodecs.INT, ExampleObject::intField,
+  StreamCodecs.optional(ByteBufCodecs.STRING_UTF8), ExampleObject::optionalStringField,
+  ByteBufCodecs.holderRegistry(Registries.ITEM), ExampleObject::holderItemField,
+  ExampleObject::new
+);
+```
+
+As many packets have not been updated to use a codec-based approached, they can use `Packet#codec` to turn a read/write implementation into a codec. This method takes in a `StreamMemberEncoder` instead of a `StreamEncoder` as write methods are usually instance methods on the packet class.
+
+```java
+// For some ExamplePacket with ExamplePacket(RegistryFriendlyByteBuf) and ExamplePacket#write(RegistryFriendlyByteBuf)
+
+public static final StreamCodec<RegistryFriendlyByteBuf, ExamplePacket> STREAM_CODEC = Packet.codec(
+  ExamplePacket::write, ExamplePacket::new
+);
+```
+
+If read and write methods have suddently disppeared, or the network handling has been moved, it is most likely handled by a `StreamCodec` directly within the object class or in a package within `net.minecraft.network.codec`. Packets themselves do not contain the `StreamCodec` and instead are directly registered via `ProtocolInfoBuilder#addPacket`. `Packet`s now contain a `PacketType` with the name of the packet and the direction the packet is sent.
+
+Here are some of the classes that uses stream codecs for their implementation logic:
+
+- `net.minecraft.core.particles.ParticleType#getDeserializer` -> `streamCodec`
+- `net.minecraft.network.syncher.EntityDataSerializer`
+- `net.minecraft.world.item.crafting.RecipeSerializer#fromNetwork`, `toNetwork` -> `streamCodec`
+- `net.minecraft.world.level.gameevent.PositionSourceType#read`, `write` -> `streamCodec`
+
+## Sub Predicate Types
+
+Entities and items now have sub predicates that can be applied for specific entities and items. Entities store this within the `type_specific` json object in the `EntityPredicate`. Items store this within the `predicates` json object in the `ItemPredicate`. Each of these are registered to their own built in registry, requiring some codec object.
+
+- `net.minecraft.advancements.critereon.EntityVariantPredicate` -> `EntitySubPredicates$EntityVariantPredicateType`
+  - All variant predicates are within `EntitySubPredicates`
+
+## Don't you like Holders?
+
+Most methods now take in a `Holder` of a registry object rather than the registry object directly. As such, direct references should not be used.
+
+- `net.minecraft.client.renderer.FogRenderer$MobEffectFogFunction#getMobEffect` returns a `Holder<MobEffect>`
+- `net.minecraft.gametest.framework.GameTestHelper` now takes in a `Holder<MobEffect>`
+- `net.minecraft.network.chat.ChatType$Bound` now takes in a `Holder<ChatType>`
+- `net.minecraft.world.effect.MobEffect#addAttributeModifier` now takes in a `Holder<Attribute>`
+- `net.minecraft.world.effect.MobEffectInstance` now takes in a `Holder<MobEffect>`
+- `net.minecraft.world.entity.Entity#gameEvent` now takes in a `Holder<GameEvent>`
+- `net.minecraft.world.item.ArmorItem` now takes in a `Holder<ArmorMaterial>`
+- `net.minecraft.world.level.LevelAccessor#gameEvent` now takes in a `Holder<GameEvent>`
+- `net.minecraft.world.level.gameevent.GameEventListener#handleGameEvent` now takes in a `Holder<GameEvent>`
+- `net.minecraft.world.level.gameevent.GameEventListenerRegistry#visitInRangeListeners` now takes in a `Holder<GameEvent>`
+
+## ExtraCodecs to DataFixerUpper
+
+Many of the methods that were commonly used in `ExtraCodecs` has been migrated or combined in some other appropriate place within `Codec` or `DataResult`. Most of the names are synonymous, so they just need to be replaced with the correct class.
+
+- `net.minecraft.Util#getOrThrow`, `getPartialOrThrow` -> `com.mojang.serialization.DataResult#getOrThrow`, `getPartialOrThrow`
+- `net.minecraft.util.ExtraCodecs
+  - `withAlternative` -> `com.mojang.serialization.Codec#withAlternative`
+  - `validate` -> `com.mojang.serialization.Codec#validate`
+  - `strictOptionalField` -> `com.mojang.serialization.Codec#optionalFieldOf` as the method is now strict by default
+    - `optionalFieldOf` previously has now been replaced by `lenientOptionalFieldOf`
+  - `xor` -> `Codec#xor`
+  - `either` -> `Codec#either`
+  - `stringResolverCodec` -> `Codec#stringResolver`
+  - `recursive` -> `Codec#recursive`
+  - `lazyInitializedCodec` -> `Codec#lazyInitialized`
+  - `sizeLimitedString` -> `Codec#sizeLimitedString`
+
+## Codec Replacements
+
+A lot of read/write methods have been replaced with Codec equivalents.
+
+- `net.minecraft.nbt.NbtUtils#readGameProfile`, `#writeGameProfile` -> `ExtraCodecs#GAME_PROFILE`
+- `net.minecraft.network.FriendlyByteBuf`
+  - `writeId`, `readById` -> `Registry#getId`, `byId` and `FriendlyByteBuf#writeVarInt`
+  - `readCollection`, `writeCollection`, `readList`, `readMap`, `writeMap`, `writeOptional`, `readOptional`, `writeNullable`, `readNullable` take in decoders and encoders for streams
+  - `writeEither`, `readEither` -> `Codec#either`
+  - `readComponent`, `readComponentTrusted`, `writeComponent` -> `ComponentSerialization#STREAM_CODEC`, `TRUSTED_STREAM_CODEC`
+  - `writeItem`, `readItem` -> `ItemStack#OPTIONAL_STREAM_CODEC`
+  - `readGameProfile`, `writeGameProfile` ->  `ExtraCodecs#GAME_PROFILE`
+  - `readGameProfileProperties`, `writeGameProfileProperties` -> `ExtraCodecs#PROPERTY_MAP`''
+  - `readProperty`, `writeProperty` -> `ExtraCodecs#PROPERTY`
+
+## Removed Redundant PoseStacks
+
+Most methods that passed around the raw `PoseStack` has had the parameter removed. Now, no `PoseStack`, or only the relevant `Pose` or `Matrix4f`, is passed.
+
+- `net.minecraft.client.renderer.GameRenderer#renderLevel` no longer takes in a `PoseStack`
+- `net.minecraft.client.renderer.LevelRenderer`
+  - `prepareCullFrustum` no longer takes in a `PoseStack` and only takes in the `Matrix4f` that is being operated on
+  - `renderLevel` no longer takes in a `PoseStack`
+  - `renderSectionLayer` no longer takes in a `PoseStack`
+  - `renderSky` no longer takes in a `PoseStack` and only takes in the `Matrix4f` that is being operated on
+
+### No more Matrix4f in Lighting Setup
+
+`Matrix4f` is no longer passed into the shader uniforms when setting up level lighting.
+
+- `com.mojang.blaze3d.platform.Lighting#setupForEntityInInventory` - Setup light direction uniforms for entity displayed in inventory
+- `net.minecraft.client.particle.ParticleEngine#render(PoseStack, MultiBufferSource$BufferSource, LightTexture, Camera, float)` -> `render(LightTexture, Camera, float)`
+
+## ItemInteractionResult
+
+There is now a separation when it comes to interacting with an item compared interacting with anything else. When interacting where an item is supposed to be called, methods will now return an `ItemInteractionResult`. An `ItemInteractionResult` can be mapped to an `InteractionResult`. The methods below now return an `ItemInteractionResult`.
+
+- `net.minecraft.core.cauldron.CauldronInteraction`
+  - `interact`
+  - `fillBucket`
+  - `emptyBucket`
+
+## Enchantments, now with Definitions
+
+`Enchantment`s have been overhauled to now hold a single record known as an `EnchantmentDefinition`. This record contains tags for the supported items this enchantment can be applied to, the items it would be considered a primary enchantment, the weight of obtaining the enchantment, the max level the enchantment can be, the minimum and maximum cost of the enchantment, the cost to repair in an anvil, the feature flags, and the slots the enchantment can be applied to.
+
+These values can be created using `Enchantment#definition`, while the cost can be computed either via `constantCost` for every level, or `dynamicCost` for an increasing cost per level. Enchantments still need to be registered like any other built-in registry.
+
+For the tags, there are `minecraft:enchantable/*` tags which refer to a list of items that can be applied with that enchant. For example, `minecraft:enchantable/sword` contains all swords. If one of these tags do not match your criteria, you can create a separate enchantable tag for specifically your enchantment. It is recommended to add other items via other enchantable tag groups first. This replaces `EnchantmentCategory`.
+
+`EnchantmentHelper` methods have been replaced to use the `ItemEnchantment`s data component object instead of a raw `CompoundTag`.
+
+- `getRarity` -> `getWeight`
+- `getAnvilCost` - The minimum cost needed to repair in an anvil
+- `getDamageBonus(int, MobType)` -> `getDamageBonus(int, EntityType<?>)`
+- `doPostItemStackHurt` - Executes when an item with this enchantment damages an entity
+
+## Blocks: From public to protected
+
+Many of the methods within `Block` are now protected, to prevent direct access except through the `BlockState`, or has had some changes to its logic. The following methods are now protected:
+
+- `updateIndirectNeighbourShapes`
+- `isPathfindable`
+- `updateShape`
+- `skipRendering`
+- `neighborChanged`
+- `onPlace`
+- `onRemove`
+- `onExplosionHit`
+- `useWithoutItem`
+- `useItemOn`
+- `triggerEvent`
+- `getRenderShape`
+- `useShapeForLightOcclusion`
+- `isSignalSource`
+- `getFluidState`
+- `hasAnalogOutputSignal`
+- `getMaxHorizontalOffset`
+- `getMaxVerticalOffset`
+- `rotate`
+- `mirror`
+- `canBeReplaced`
+- `getDrops`
+- `getSeed`
+- `getOcclusionShape`
+- `getBlockSupportShape`
+- `getInteractionShape`
+- `getLightBlock`
+- `getMenuProvider`
+- `canSurvive`
+- `getShadeBrightness`
+- `getAnalogOutputSignal`
+- `getShape`
+- `getCollisionShape`
+- `isCollisionShapeFullBlock`
+- `isOcclusionShapeFullBlock`
+- `getVisualShape`
+- `randomTick`
+- `tick`
+- `getDestroyProgress`
+- `spawnAfterBreak`
+- `attack`
+- `getSignal`
+- `entityInside`
+- `getDirectSignal`
+- `onProjectileHit`
+- `propagatesSkylightDown`
+- `isRandomlyTicking`
+- `getSoundType`
+
+Here are some other changes:
+
+- `isPathfindable(BlockState, BlockGetter, BlockPos, PathComputationType)` -> `isPathfindable(BlockState, PathComputationType)`
+- `use` -> `useWithoutItem`
+- `BlockStateBase$neighborChanged` -> `handleNeighborChanged`
+- `net.minecraft.world.level.block.Block`
+  - `isRandomlyTicking` -> `BlockBehaviour#isRandomlyTicking`
+  - `propagatesSkylightDown` -> `BlockBehaviour#propagatesSkylightDown`
+  - `getSoundType` -> `BlockBehaviour#getSoundType`
+
+## ItemStack Max Stack Size 99
+
+The hard limit has been raised from 64 to 99 for `ItemStack`s.
+
+## No more magicalSpecialHackyFocus
+
+`net.minecraft.client.gui.components.events.ContainerEventHandler#magicalSpecialHackyFocus` has been removed. It did nothing but set the focused element.
+
+## Bootstap? No! It's Bootstrap!
+
+`net.minecraft.data.worldgen.BootstapContext` has finally been renamed to `BootstrapContext`!
+
+## Minor Migrations
+
+The following is a list of useful or interesting additions, changes, and removals that do not deserve their own section in the primer.
+
+### StringUtil
+
+Most string transformation utility methods have been moved to `net.minecraft.util.StringUtil` with the same name
+
+- `net.minecraft.Util#isBlank`, `isWhitespace`
+- `net.minecraft.SharedConstants#isAllowedChatCharacter`, `filterText`
+
+### Advancement Network Codecs
+
+All network methods for advancements (`read`, `write`) have been made private or removed. They are replaced by `StreamCodec`s taking in a `RegistryFriendlyByteBuf`.
+
+### Collection Criteria Predicates
+
+The following predicates have been added for handling criteria triggers:
+
+- `CollectionContentsPredicate` -> Returns true if all contents of a collection match the given predicate(s)
+- `CollectionCountsPredicate` -> Returns true if the number of contents that match the given predicate(s) is within the specified bounds
+- `CollectionPredicate` -> Returns true depending on the above predicates and whether the size of the collection matches the size specified
+
+### Entity Slot Criteria
+
+A new field called `slots` on the `EntityPredicate` can now check the entity's inventory for a match.
+
+### Recipe Book Categories throw on default
+
+Recipe book methods that attempt to get a `RecipeBookCategories` will now throw a `MatchException` if no corresponding category exists.
+
+- `net.minecraft.client.ClientRecipeBook#getCategory`
+- `net.minecraft.client.RecipeBookCategories#getCategories`
+
+### Gui Breakup
+
+Most logic within the `Gui` class has been separated to private methods. Additionally, some fields have been removed in favor of using their `GuiGraphics` counterparts.
+
+- `renderEffects`, `renderJumpMeter`, `renderExperienceBar`, `renderSelectedItemName`, `renderDemoOverlay` is now private
+- `renderSavingIndicator` is now public and takes in a float representing the tick rate
+- `screenWidth`, `screenHeight` -> `GuiGraphics#guiWidth`, `GuiGraphics#guiHeight`
+- `itemRenderer` has been completely removed
+
+### Map Decoration Textures
+
+Map decoration textures are now managed by an atlas that is stiched together. Because of this, the map id is now stored within a record `MapId` holding the current id of the map to render as a texture. `MapRenderer` uses this `MapId` instead of a integer.
+
+To access the texture manager, call `Minecraft#getMapDecorationTextures`.
+
+- `net.minecraft.client.multiplayer.ClientLevel`
+  - `getMapData(String)` -> `getMapData(MapId)`
+  - `overrideMapData(String, MapItemSavedData)` -> `overrideMapData(MapId, MapItemSavedData)`
+  - `getAllMapData` returns a `Map<MapId, MapItemSavedData>`
+  - `addMapData(Map<String, MapItemSavedData>)` -> `addMapData(Map<MapId, MapItemSavedData>)`
+- `net.minecraft.world.level.Level`
+  - `setMapData(String, MapItemSavedData)` -> `setMapData(MapId, MapItemSavedData)`
+  - `getFreeMapId` returns a `MapId`
+
+### Font Options
+
+Font providers now have variant filters. There are currently two available: uniform and japanese variants. These filters determine whether the variant should be used. Most font cosntruction methods allows a filter or a font option to be passed in.
+
+- `com.mojang.blaze3d.font.GlyphProvider$Conditional` - Filters whether a glyph provider should be added to the list of available providers when loading a font option
+- `net.minecraft.client.Options#japaneseGlyphVariants` - A new option that, when enabled, will use different variants of Japanese glyphs
+- `net.minecraft.client.gui.font.FontManager#updateOptions` - Reloads the available font options to choose from
+- `net.minecraft.client.Minecraft#selectMainFont` -> `updateFontOptions`
+  - This is not one-to-one as the fonts are now options in the menu
+- `net.minecraft.client.gui.font.FontSet#reload` takes in a conditional holding the filters for a glyph provider and the set of font options to reload
+
+### Screen Backgrounds
+
+`Screen#renderBackground` has been broken into three steps: `renderPanorama` if the level is null, `renderBlurredBackground` which processes the blur effect to apply to the background, and `renderMenuBackground` which rends the background texture to the screen. There is also an additional method for rendering a transparent background called `renderTransparentBackground` which is called when rendering the background in `AbstractContainerScreen`.
+
+`renderDirtBackground` -> `renderMenuBackground`
+
+### Holder Lookups in Data Providers
+
+Some methods in data providers now take in a `HolderLookup$Provider` to get any relevant registry objects that are not explicitly accessible or built in.
+
+- `net.minecraft.data.recipes.RecipeProvider` now takes in a `CompletableFuture<HolderLookup.Provider>`
+  - `buildAdvancement` now takes in a `HolderLookup$Provider`
+
+### ResourceKey References
+
+Many references to `ResourceLocation`s now take in an associated `ResourceKey` instead with the generic tied to the registry object in question.
+
+- `net.minecraft.data.loot.BlockLootSubProvider` now takes in a `Map<ResourceKey<LootTable>, LootTable.Builder>` instead of a `Map<ResourceLocation, LootTable.Builder>`
+- `net.minecraft.data.loot.LootTableProvider(PackOutput, Set<ResourceLocation>, List<LootTableProvider.SubProviderEntry>)` -> `LootTableProvider(PackOutput, Set<ResourceKey<LootTable>>, List<LootTableProvider.SubProviderEntry>, CompletableFuture<HolderLookup.Provider>)
+- `net.minecraft.data.loot.LootTableSubProvider#generate(BiConsumer<ResourceLocation, LootTable.Builder>)` -> `generate(HolderLookup.Provider, BiConsumer<ResourceKey<LootTable>, LootTable.Builder>)`
+
+### Static methods in FriendlyByteBuf
+
+Static methods for writing and reading data have been added to `FriendlyByteBuf` which takes in the same parameters of the instance method, along with the `ByteBuf` to write to.
+
+### Loot Registries
+
+Loot data are now handled through dynamic registries, specifically ones that can be reloaded by the `/reload` command. This means that any previous references, such as `LootDataManager`, no longer exist. They can be queried via `reloadableRegistries` in `MinecraftServer` or `Level`
+
+### PackLocationInfo
+
+Pack information stored within resources are now stored within a `PackLocationInfo` object. Parameters such as `name` or `isBuiltIn` is stored directly on this object (e.g. `id` and `knownPackInfo`, respectively). All classes within `net.minecraft.server.packs` have been updated to accomdate this change.
+
+A `KnownPack` is simply a synced key and version indicating where the resource orginated from. As such, both the server and client must have the same contents as the `KnownPack` is used to avoid syncing the entire pack when unnecessary.
+
+### DispatchCodecs now MapCodecs
+
+`Codec#dispatch` now takes in a `MapCodec` instead of a `Codec`. All other codecs used for dispatch have been updated to a `MapCodec`:
+
+- `net.minecraft.core.particles.ParticleType#codec`
+- `net.minecraft.client.renderer.texture.atlas.SpriteSources#register`
+- `net.minecraft.client.renderer.texture.atlas.SpriteSourceType`
+- `net.minecraft.util.valueproviders.FloatProviderType#codec`
+- `net.minecraft.util.valueproviders.IntProviderType#codec`
+- `net.minecraft.world.item.crafting.RecipeSerializer#codec`
+- `net.minecraft.world.level.biome.BiomeSource#codec`
+- `net.minecraft.world.level.chunk.ChunkGenerator#codec`
+- `net.minecraft.world.level.gameevent.PositionSourceType#codec`
+- `net.minecraft.world.level.levelgen.blockpredicates.BlockPredicateType#codec`
+- `net.minecraft.world.level.levelgen.carver.WorldCarver#configuredCodec`
+- `net.minecraft.world.level.levelgen.feature.Feature#configuredCodec`
+- `net.minecraft.world.level.levelgen.feature.featuresize.FeatureSizeType#codec`
+- `net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacerType#codec`
+- `net.minecraft.world.level.levelgen.feature.rootplacers.RootPlacerType#codec`
+- `net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProviderType#codec`
+- `net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecoratorType#codec`
+- `net.minecraft.world.level.levelgen.feature.trunkplacers.TrunkPlacerType#codec`
+- `net.minecraft.world.level.levelgen.heightproviders.HeightProviderType#codec`
+- `net.minecraft.world.level.levelgen.placement.PlacementModifierType#codec`
+- `net.minecraft.world.level.levelgen.structure.Structure#simpleCodec`
+- `net.minecraft.world.level.levelgen.structure.StructureType#codec`
+- `net.minecraft.world.level.levelgen.structure.placement.StructurePlacementType#codec`
+- `net.minecraft.world.level.levelgen.structure.pools.StructurePoolElementType#codec`
+- `net.minecraft.world.level.levelgen.structure.pools.alias.PoolAliasBinding#codec`
+- `net.minecraft.world.level.levelgen.structure.templatesystem.PosRuleTestType#codec`
+- `net.minecraft.world.level.levelgen.structure.templatesystem.RuleTestType#codec`
+- `net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType#codec`
+- `net.minecraft.world.level.levelgen.structure.templatesystem.rule.blockentity.RuleBlockEntityModifierType#codec`
+- `net.minecraft.world.level.storage.loot.entries.CompositeEntryBase#createCodec`
+- `net.minecraft.world.level.storage.loot.entries.LootPoolEntryType`
+- `net.minecraft.world.level.storage.loot.functions.LootItemFunctionType`
+- `net.minecraft.world.level.storage.loot.predicates.LootItemConditionType`
+- `net.minecraft.world.level.storage.loot.providers.nbt.LootNbtProviderType`
+- `net.minecraft.world.level.storage.loot.providers.number.LootNumberProviderType`
+- `net.minecraft.world.level.storage.loot.providers.score.LootScoreProviderType`
+
+### Packrat Parser
+
+The [pakrat parser](https://en.wikipedia.org/wiki/Packrat_parser) has been added to `net.minecraft.util.parsing.packrat` to read and parse strings from commands. However, this implementation can be used generically by creating your own grammar.
+
+### Entity Attachments
+
+An `EntityAttachment` is a definition of where a given point lies the entity. For example, a name tag could be directly on top of an entity or underneath it. Each `EntityAttachment` contains a fallback of where the point should go if there is none set. Multiple points can be registered for a given `EntityAttachment`.
+
+`EntityAttachment`s are added from the `EntityType$Builder` using one of the `*Attachments`, `*Offset`, or `attach` methods. They can then be accessed from the entity using `#getAttachments`. To get an attachment vector value, specify the attachment, index, and y rotation, calling `EntityAttachments#getNullable` if you want null to be returned, or `get` if you want an error to be thrown.
+
+### Dyeables
+
+Dyable armor is now a setting on the `ArmorMaterial$Layer` and an item tag `minecraft:dyeable` rather than a completely separate class. When true, this will tint the armor texture provided. The `ItemStack` must have a `DYED_COLOR` data component to read the tint color from. The tag allows this component to be added through the armor dyeing crafting table recipe.
+
+### Potion Brewing
+
+`PotionBrewing` is now an instance class on the `MinecraftServer` that is passed through the `Level`. This means all static methods are now instance methods.
+
+### TooltipProvider
+
+Tooltips for a particular object stored on an item (usually for `DataComponent`s) are now implemented via `TooltipProvider`. This interface has one method which takes in the context of the item tooltip, a consumer to supply the tooltip contents to, and the currently set tooltip flags. Calling this is usualy within `Item#appendHoverText`:
+
+```java
+@Override
+public void appendHoverText(ItemStack stack, Item.TooltipContext ctx, List<Component> tooltips, TooltipFlag flags) {
+  // Get some TooltipProvider implementation provider
+  provider.addToTooltip(ctx, tooltips::add, flags);
+}
+```
+
+### New Criteria Triggers
+
+- `BAD_OMEN` -> `RAID_OMEN`
+- `DEFAULT_BLOCK_USE` (`minecraft:default_block_use`)
+- `ANY_BLOCK_USE` (`minecraft:any_block_use`)
+- `CRAFTER_RECIPE_CRAFTED` (`minecraft:crafter_recipe_crafted`)
+- `FALL_AFTER_EXPLOSION` (`minecraft:fall_after_explosion`)
+
+### New Loot Context Parameters
+
+- `EQUIPMENT` -> `ORIGIN`, `THIS_ENTITY`
+- `VAULT` -> `ORIGIN`, `THIS_ENTITY`?
+- `BLOCK_USE` -> `ORIGIN`, `THIS_ENTITY`, `BLOCK_STATE`
+- `SHEARING` -> `ORIGIN`, `THIS_ENTITY`?
+
+### Additions
+
+- `com.mojang.blaze3d.vertex.PoseStack$Pose`
+  - `transformNormal` - Applies a transform to the normal within the given pose
+  - `copy` - Makes a deep copy of the current pose. Does not add to stack
+- `com.mojang.math.MatrixUtil`
+  - `isPureTranslation` - Returns true if the matrix has only been translated from the identity
+  - `isOrthonormal` - Returns true if the upper left 3x3 submatrix is orthogonal
+- `net.minecraft.Util`
+  - `toMutableList` - Creates a collector for a mutable list
+  - `getRegisteredName` - Gets the registry name of an object, or `[unregistered]` if not registered
+  - `allOf` - Combines all predicates into a single predicate using ANDs
+  - `copyAndAdd` - Creates a new immuatble list with the added element
+  - `copyAndPut` - Creates a new immutable map with the added element
+- `net.minecraft.client.GuiMessage#icon` - Returns the icon for the message tag when present, otherwise null
+- `net.minecraft.client.Minecraft#disconnect(Screen, boolean)` where the boolean, when true, will not clear downloaded resource packs
+- `net.minecraft.client.MouseHandler#handleAccumulatedMovement` - Handles the movement of the mouse when running the tick
+- `net.minecraft.client.OptionInstance#createButton(Options)` - Creates a button at (0,0) with a width of 150
+- `net.minecraft.client.Options`
+  - `menubackgroundBlurriness` - A new option to determine how blurry the background of a menu should be
+- `net.minecraft.client.gui.GuiGraphics`
+  - `containsPointInScissor` - Returns true if the given point is within the top entry of the scissor stack
+  - `fillRenderType` - Creates a filled quad for the given `RenderType`
+- `net.minecraft.client.LayeredDraw` - A class that renders objects on top of each other. The distance between each layer is translated 200 units in the Z direction to allow proper stacking
+- `net.minecraft.client.gui.components.AbstractSelectionList`
+  - `updateSize` - Updates the size of the list to display
+  - `updateSizeAndPosition` - Updates the size and position of the list to display
+  - `getDefaultScrollbarPosition` - Gets the x position where the scrollbar would normally render
+  - `getListOutlinePadding` - Gets the padding to offset the x position of the scrollbar
+  - `getRealRowLeft` - Gets the actual left position of the list
+  - `getRealRowRight` - Gets the actual right position of the list
+- `net.minecraft.client.gui.components.ChatComponent`
+  - `storeState` - Returns the current state of the chat messages stored in the component
+  - `restoreState` - Sets the current state of the chat messages to a previous setup
+- `net.minecraft.client.gui.components.CycleButton#create(Component, CycleButton$OnValueChange)` - Constructs a new button at (0,0) of size (150,20)
+- `net.minecraft.client.gui.components.DebugScreenOverlay
+  - `showFpsCharts` - When true, renders the FPS chart
+  - `logRemoteSample` - Logs a full sample for the specified sample type
+- `net.minecraft.client.gui.components.FocusableTextWidget#containWithin` - Sets the max width to contain the specified size excluding padding
+- `net.minecraft.client.gui.components.TabButton$renderMenuBackground` - Renders the background of the screen
+- `net.minecraft.client.gui.components.debugchart.AbstractDebugChart`
+  - `drawDimensions` - Draws the sample and additional information
+  - `drawMainDimension` - Draws the sample to the display
+  - `drawAdditionalDimensions` - Draws additional information about the sample
+  - `getValueForAggregation` - Reads the data within the sample storage
+- `net.minecraft.client.gui.components.toasts.SystemToast`
+  - `onLowDiskSpace` - Creates a system toast that notifies the disk space needed to write the chunk is low
+  - `onChunkLoadFailure` - Creates a system toast that notifies the chunk has failed to load
+  - `onChunkSaveFailure` - Creates a system toast that notifies the chunk has failed to save
+- `net.minecraft.client.gui.font.FontSet#name` - the name of the font set
+- `net.minecraft.client.gui.font.providers.FreeTypeUtil` - A utility for interactions the Freetype Font API
+- `net.minecraft.client.gui.layouts.HeaderAndFooterLayout
+  - `getContentHeight` - Gets the y position of the content
+  - `addTitleHeader` - Adds a string widget to the header
+- `net.minecraft.client.gui.navigation.ScreenRectangle#containsPoint` - Checks whether the point is within the current rectangle
+- `net.minecraft.client.gui.screens.Screen#setInitialFocus` - This method should be overridden to set the initial focused widget on screen
+- `net.minecraft.client.multiplayer.ClientPacketListener`
+  - `scoreboard` - Gets the sent scoreboard from the server
+  - `potionBrewing` - Gets the sent brewing information from the server
+- `net.minecraft.client.multiplayer.KnownPacksManager` - A class that holds the known packs on the client from the server
+- `net.minecraft.client.multiplayer.RegistryDataCollector` - A collector which holds the contents and tags of the available registries
+- `net.minecraft.client.multiplayer.TagCollector` - A collector which holds the tags of the available registries
+- `net.minecraft.client.multiplayer.ServerData`
+  - `state` - Gets the current state of the server data
+  - `setState` - Sets the current state of the server data
+- `net.minecraft.client.particle.Particle$LifetimeAlpha` - A particle utility for handing animated alpha over the particle's lifetime using linear interpolation
+- `net.minecraft.client.renderer.GameRenderer`
+  - `loadBlurEffect` - Loads the effect of the blur post processor (private)
+  - `processBlurEffect` - Processes the blur effect, applies the 'Radius' uniform using the menu blackground blurriness option
+  - `getRendertypeCloudsShader` - Gets the shader for the clouds render type
+- `net.minecraft.client.renderer.entity.EntityRenderer#getShadowRadius` - Returns the radius of the entity's shadow
+- `net.minecraft.client.renderer.entity.layers.WolfArmorLayer` - Render layer for wolf armor
+- `net.minecraft.client.sounds.ChunkedSampleByteBuf` - A byte buffer chunked into multiple byte buffers
+- `net.minecraft.commands.arguments.ResourceOrIdArgument` - An argument that operates on a resource or registry object identifier
+- `net.minecraft.commands.arguments.SlotsArgument` - An argument that operates on a specific slot within a slot range
+- `net.minecraft.commands.functions.CommandFunction#checkCommandLineLength` - Commands with over 2 million characters will throw an error
+- `net.minecraft.core.BlockBox` - A rectangular prism as defined by two block positions
+- `net.minecraft.core.BlockPos`
+  - `min` - Takes the minimum coordinates between two block positions and creates a new one
+  - `max` - Takes the maximum coordinates between two block positions and createa a new one
+- `net.minecraft.core.Direction#getNearest` - Gets the direction closest to the normalized vector
+- `net.minecraft.core.Direction$Plane#length` - Gets the number of faces in a given plane
+- `net.minecraft.core.Holder`
+  - `is(Holder)` - Checks if two holders are equivalent, this method is deprecated
+  - `getRegisteredName` - Gets the registry object's identifer
+- `net.minecraft.core.HolderGetter$Provider#get` - Gets a refence holder to a registry object from the registry key and resource key
+- `net.minecraft.core.HolderLookup#createSerializationContext` - Creates a registry ops for the current registries provider
+- `net.minecraft.core.HolderSet#empty` - Gets an empty holder set
+- `net.minecraft.core.IdMap#getIdOrThrow` - Gets the id of a registry object or throws an error if not present
+- `net.minecraft.core.RegistrationInfo` - Holds information related to a specific registry object in a registry (the pack it came from and the lifecycle of the object)
+- `net.minecraft.core.Registry`
+  - `getHolder(ResourceLocation)` - Gets the object holder from its registry id
+  - `getRandomElementOf` - Gets a random element from the registry filtered by a tag
+- `net.minecraft.core.RegistrySynchronization$PackedRegistryEntry` - Holds the data for a given registry entry
+- `net.minecraft.data.tags.TagsProvider$TagAppender#addAll` - Adds a list of resource keys to the tag
+- `net.minecraft.gametest.framework.GameTest`
+  - `skyAccess` - When false, when preparing a test structure, this will spawn barrier blocks on top of the structure
+  - `manualOnly` - When true, the test can only be manually triggered and not run as part of all available tests
+- `net.minecraft.gametest.framework.GameTestHelper`
+  - `spawnItem(Item, Vec3)` - Spawns an item at the specified relative vector
+  - `findOneEntity` - Finds the first entity that matches the type
+  - `findClosestEntity` - Finds the closest entity to the specifid (x,y,z) within a given radius
+  - `findEntities` - Finds all entities within the given radius centered at (x,y,z)
+  - `moveTo` - Moves a mob to the specified position using the `Mob#moveTo` method
+  - `getEntities` - Get all entities of a given type within the test bounds
+  - `assertValueEqual` - Asserts that two objects are equivalent
+  - `assertEntityNotPresent` - Asserts that an entity is not present between the given vectors
+- `net.minecraft.gametest.framework.GameTestListener#testAddedForRerun` - A listener method that is called if the test needs to be rerun
+- `net.minecraft.gametest.framework.GameTestRunner$Builder` - A builder for constructing a runner to run the game tests
+- `net.minecraft.network.RegistryFriendlyByteBuf` - A byte buffer which holds a `RegistryAccess`
+- `net.minecraft.resources.RegistryDataLoader#load` - Methods have been added to add a `LoadingFunction` which handles how the data in the registry is loaded
+- `net.minecraft.resources.RegistryOps`
+  - `injectRegistryContext` - Wraps a `Dynamic` with some ops into a `Dynamic` with a `RegistryOps`
+  - `withParent` - Creates a `RegistryOps` with the passed in `DynamicOps` as a delegate
+- `net.minecraft.resources.ResouceLocation#readNonEmpty` - Reads a `ResourceLocation`, throwing an error if the reader buffer is empty
+- `net.minecraft.server.MinecraftServer`
+  - `reloadableRegistries` - Holds an accessor to the dynamic registries on the server
+  - `subscribeToDebugSample` - Registers a player to receive debug samples
+  - `acceptsTransfers` - Determines whether transfer packets can be sent to the server
+  - `reportChunkLoadFailure` - Reports a chunk has failed to load
+  - `reportChunkSaveFailure` - Reports a chunk has failed to save
+- `net.minecraft.server.ReloadableServerRegistries` - A class which holds registries that can be reloaded while in game (e.g., loot tables)
+- `net.minecraft.server.level.ServerLevel#getPathTypeCache` - Gets the cache of `PathType`s when computed by an entity
+- `net.minecraft.server.level.ServerPlayer
+  - `setSpawnExtraParticlesOnFall` - Sets a boolean to spawn more particles when landing from a fall
+  - `setRaidOmenPosition`, `clearRaidOmenPosition`, `getRaidOmenPosition` - Handles creating a raid from the given position
+- `net.minecraft.util.ListAndDeque` - An interface which defines an object as a list and deque that can be randomly accessed
+  - `ArrayListDeque` now implements this interface
+- `net.minecraft.util.ExtraCodecs`
+  - `sizeLimitedMap` - Makes sure the map is no larger than the specified size
+  - `optionalEmptyMap` - Returns an optional map
+- `net.minecraft.util.FastColor`
+  - `as8BitChannel` - Gets an 8-bit color value from a float between 0-1
+  - `color(int,int,int)` - Creates an opaque 32-bit color value from RGB
+  - `opaque` -> Sets the alpha of a color to 255
+  - `color(int,int)` - Creates a color with the R channel separated from the GB
+  - `colorFromFloat` - Creates a 32-bit color value from floats between 0-1
+- `net.minecraft.util.Mth#mulAndTruncate` - Multiplies a fraction by some value. Since integer division is used, the resulting division is floored
+- `net.minecraft.util.NullOps` - An intermediary that only represents a null value
+- `net.minecraft.util.ParticleUtils`
+  - `spawnParticleInBlock` - Spawns particles within a block
+  - `spawnParticles` - Spawns particles at the given position with some offset
+- `net.minecraft.util.profiling.jfr.JvmProfiler#onRegionFile(Read|Write)` - Handles logic when the region file for a given world has been read from or written to
+- `net.minecraft.world.Container#getMaxStackSize(ItemStack)` - Gets the max stack size for an `ItemStack` by getting the minimum of the container max stack size and the stack's max stack size
+- `net.minecraft.world.InteractionResult#SUCCESS_NO_ITEM_USED` - The interaction was successful but the context entity did not use an item
+- `net.minecraft.world.effect.MobEffect`
+  - `onEffectAdded` - Called when the effect is first added to the entity
+  - `onMobRemoved` - Called when the entity has been removed from the level when the effect is applied
+  - `onMobHurt` - Called when the entity is hurt when the effect is applied
+  - `createParticleOptions` - Creates the particle options to spawn around the entity
+  - `withSoundOnAdded` - Sets the sound when the effect is added to an entity
+- `net.minecraft.world.effect.MobEffectInstance`
+  - `is` - Returns true if the effect holders are equal
+  - `skipBlending` - Tells the effect not to blend with other environmental renderers (e.g. fog)
+- `net.minecraft.world.entity.AnimationState#fastForward` - Speeds up the animation based upon the animation duration and a scale amount between 0-1
+- `net.minecraft.world.entity.Crackiness` - Handles the state of how much armor has been damaged, or 'cracked'
+- `net.minecraft.world.entity.Entity`
+  - `getDefaultGravity` - Gets the default gravity value to apply to the entity
+  - `getGravity` - Gets the gravity to apply to the entity, or if there is no gravity 0
+  - `applyGravity` - Applies gravity to the delta movement of the entity.
+  - `getNearestViewDirection` - Gets the direction nearest to the current view vector
+  - `getDefaultPassengerAttachmentPoint` - Determines the default attachment point based upon the entity's current dimensions
+  - `deflection` - Determines how an entity interacts with this projectile
+  - `getPassengerClosestTo` - Gets the passenger closest to the given vector
+  - `onExplosionHit` - Handles when the entity is hit with an explosion
+  - `registryAccess` - Gets the current registry access
+- `net.minecraft.world.entity.EntityType$Builder#spawnDimensionsScale` - Sets the scale factor to apply to the entity's dimensions when attempting to spawn
+- `net.minecraft.world.entity.EquipmentSlot#BODY`
+- `net.minecraft.world.entity.EquipmentSlotGroup` - Indicates a grouping of `EquipmentSlot`s
+- `net.minecraft.world.entity.EquipmentTable` - Indicates the drop chances of a given `EquipmentSlot`
+- `net.minecraft.world.entity.EquipmentUser` - Indicates that the entity can wear equipment
+  - All `Mob`s and `ArmorStand`s are equipment users
+- `net.minecraft.world.entity.LivingEntity`
+  - `getComfortableFallDistance` - Increases the fall distance that the entity can survive without taking damage by three blocks
+  - `doHurtEquipment` - Handles when a piece of equipment should be damaged
+  - `canUseSlot` - Whether a slot can be used on an entity
+  - `getJumpPower(float)` - Gets the power of a jump from the attribute, scaling by a float and the block jump factor and adding the jump boost power
+  - `getDefaultDimensions` - Gets the base dimensions for a given pose
+  - `getSlotForHand` - Gets the `EquipmentSlot` for a given `InteractionHand`
+  - `hasInfiniteMaterials` - Whether the entity has an infinite amount of materials in its inventory. This is currently only used by the `Player`
+- `net.minecraft.world.entity.Mob`
+  - `getTargetFromBrain` - Gets the attack target of the entity, or null if none is available
+  - `stopInPlace` - Stops all navigation and entity movement
+  - `clampHeadRotationToBody` - Keeps the head movement within the bounds of the body
+  - `getBodyArmorItem`, `canWearBodyArmor`, `isWearingBodyArmor`, `isBodyArmorItem`, `setBodyArmorItem` - Logic for handling armor in the `BODY` slot
+  - `mayBeLeashed` - If the entity can be leashed
+- `net.minecraft.world.entity.SlotAccess#of` - Creates a `SlotAccess` using a supplier, consumer setup
+- `net.minecraft.world.entity.SpawnPlacements#isSpawnPositionOk` - If the entity can spawn in this position
+- `net.minecraft.world.entity.ai.attributes.AttributeInstance#addOrUpdateTransientModifier` - Updates a modifier value to the current one if it is already present, otherwise adds it
+- `net.minecraft.world.entity.ai.behavior.Swim#shouldSwim` - Checks whether the entity can swim
+- `net.minecraft.world.entity.ai.navigation.PathNavigation#moveTo` - A `moveTo` method which takes in a close enough distance
+- `net.minecraft.world.entity.monster.AbstractSkeleton`
+  - `getHardAttackInterval` - After how many ticks the entity will attack when in the hard difficulty
+  - `getAttackInterval` - After how many ticks the entity will attack when not in the hard difficulty
+- `net.minecraft.world.entity.player.Inventory#contains(Predicate)` - Whether a stack in the inventory matches the predicate
+- `net.minecraft.world.entity.player.Player#canInteractWithEntity` - Whether the player can interact with another entity
+- `net.minecraft.world.entity.projectile.AbstractArrow`
+  - `getDefaultPickupItem`, `setPickupItemStack` - Gets the default pickup item if the actual item stack cannot be obtained or is empty
+  - `getSlot` - Gets the slot access of the pickupable stack
+- `net.minecraft.world.entity.projectile.Projectile`
+  - `getMovementToShoot` - Gets the movement to apply to the entity when shooting
+  - `hitTargetOrDeflectSelf` - Gets the deflection status of the projectile
+  - `deflect` - Deflects the entity
+  - `onDeflection` - What to do when this projectile is deflected
+- `net.minecraft.world.entity.projectile.ProjectileDeflection` - The status of how a projectile can be deflected, typically on punch
+- `net.minecraft.world.entity.raid.Raider`
+  - `isCaptain` - Whether the entity is a captain of a raid
+  - `hasRaid` - If the entity has a raid to do
+- `net.minecraft.world.entity.vehicle.ContainerEntity#getBoundingBox` - Gets the bounding box of the entity
+- `net.minecraft.world.flag.FeatureFlagSet`
+  - `isEmpty` - Whether there are no feature flags enabled
+  - `intersects` - Whether two feature flag sets contain at least one similar feature flag
+  - `subtract` - Returns a feature flag set without the flags of the parameter
+- `net.minecraft.world.food.FoodConstants#saturationByModifier` - Takes in the number of hearts to heal and how the saturation should be multiplied by
+- `net.minecraft.world.inventory.SlotRange` - Defines a range of slot indexes that can be referenced from some string prefix plus the index (all available `SlotRange`s are in `SlotRanges`
+- `net.minecraft.world.item.ArmorItem$Type` is now `StringRepresentable`
+  - `hasTrims` - Whether the armor type supports trims
+- `net.minecraft.world.item.ArmorMaterial#layers` - Stores information about the texture location of the armor type
+- `net.minecraft.world.item.DiggerItem#createAttributes` - Creates the attribute modifiers given for a tier, attack damage, and attack speed
+- `net.minecraft.world.item.Item`
+  - `components` - Gets the data component map
+  - `getDefaultMaxStackSize` - Reads the max stack size of the component, or defaults to 1
+  - `getAttackDamageBonus` - Applies a bonus to the attack damage when in the main hand
+  - `getBreakingSound` - The sound even to play when the item breaks
+  - `$Properties#component` - Adds a data component to the item
+  - `$Properties#attributes` - Sets the attribute modifiers for the item
+  - `$TooltipContext` - Holds access to the available registries, tick rate, and `MapItemSavedData` when coming from a `Level`
+- `net.minecraft.world.item.ItemStack`
+  - `getPrototype` - Gets the component map from the item
+  - `getComponentsPatch` - Gets the patches to the component map on the current `ItemStack`
+  - `validateComponents` - Validates whether certain components can be on the component map
+  - `parse` - Parses the stack from a tag
+  - `parseOptional` - Parses the stack from a tag, or returns an empty stack when not present
+  - `save` - Saves the stack to a tag, or returns an empty tag
+  - `transmuteCopy` - Creates a new copy, providing the component patch
+  - `transmuteCopyIgnoreEmpty` - Creates a new copy without checking whether the stack is empty or not
+  - `listMatches` - Returns whether two lists of stacks match each other 1-to-1
+  - `lenientOptionalFieldOf` - Creates a map codec with an optional stack
+  - `hashItemAndComponents` - Computes the hash code for a given stack
+  - `hashStackList` - Computes the hash code for a list of stacks
+  - `set` - Sets a data component value
+  - `update` - Updates a data component value
+  - `applyComponentsAndValidate` - Applies a component patch and validates the components
+  - `applyComponents` - Applies a patch to the component map and validates
+  - `getEnchantments` - Gets the item enchantments from the data component
+  - `forEachModifier` - Applies a consumer for every modifier in the attribute modifiers
+  - `limitSize` - Sets the count of the stack if the current count is larger than the limit
+  - `consume` - Consumes a single item
+- `net.minecraft.world.item.ProjectileItem` - Defines an item that can function like a projectile. Contains logic for constructing the projectile and shooting it either from the entity or dispenser
+  - `ProjectileWeaponItem` contains protected implementations of these methods to be set when implementing `ProjectileItem`
+- `net.minecraft.world.item.SwordItem#createAttributes` - Creates the attribute modifiers given for a tier, attack damage, and attack speed
+- `net.minecraft.world.item.Tier`
+  - `getIncorrectBlocksForDrops` - A negative restraint preventing certain blocks from receiving a boost from this tier
+  - `createToolProperties` - Creates a `Tool` given the tag containing the blocks to speed up mining for
+- `net.minecraft.world.level.ExplosionDamageCalculator#getKnockbackMultiplier` - Returns a scalar on how much knockback to apply to the entity
+- `net.minecraft.world.level.SpawnData#isValidPosition` - Whether the entity can spawn within the specified block and sky light
+- `net.minecraft.world.level.block.BonemealableBlock`
+  - `getParticlePos` - Gets the position the particle should spawn
+  - `getType` - Gets the type of effect the bonemeal has on particle spawning
+- `net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity#invalidateCache` - Clears the fuel map
+- `net.minecraft.world.level.block.entity.BannerBlockEntity#getPatterns` - Gets the stored patterns on the banner
+- `net.minecraft.world.level.block.entity.BlockEntity`
+  - `applyImplicitComponents` - Reads any data stored on the component input for the block entity
+  - `collectImplicitComponents` - Writes any data to be stored on the stack
+  - `removeComponentsFromTag`- Removes any information that is stored doubly within the `BlockEntityTag` that is handled by a data component
+  - `components`, `setComponents` - Getters and setters for the stored data component map
+- `net.minecraft.world.level.block.entity.Hopper#isGridAligned` - Returns true if the hopper is always aligned to the block grid
+- `net.minecraft.world.level.block.entity.trialspawner.PlayerDetector$EntitySelector` - Determines how to select an entity from a given context
+- `net.minecraft.world.level.chunk.storage.RegionFile#getPath` - Gets the path of the region file
+- `net.minecraft.world.level.chunk.storage.RegionFileInfo` - A record which contains the current level name, dimension, and the type of the region (e.g. chunk)
+- `net.minecraft.world.level.levelgen.structure.Structure#getMeanFirstOccupiedHeight` - Gets the average height of the four corners of the structure
+- `net.minecraft.world.level.levelgen.structure.BoundingBox#inflatedBy(int, int, int)` - Inflates the size of the box by the specified (x,y,z) in both directions
+- `net.minecraft.world.level.levelgen.structure.placement.StructurePlacement`
+  - `applyAdditionalChunkRestrictions` - Returns whether the structure should generate given some level of frequency reduction
+  - `applyInteractionsWithOtherStructures` - Returns whether the structure should generate based on the exclusion zones
+- `net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate#updateShapeAtEdge(LevelAccessor, int, DiscreteVoxelShape, BlockPos)` - Calls `BlockState#updateShape` on all blocks on the edges of the structure
+- `net.minecraft.world.level.pathfinder.NodeEvaluator#getPathType(Mob, BlockPos)` - Gets the path type by calling `getPathType(PathfindingContext, int, int, int)` where the `PathfindingContext` is constructed from the mob and the three integers by unwrapping the `BlockPos`
+- `net.minecraft.world.level.pathfinder.PathfindingContext` - A context object which holds information related to the current world, cache, and mob position
+- `net.minecraft.world.level.storage.LevelStorageSource$LevelStorageAccess`
+  - `estimateDiskSpace` - Returns how much disk space is left to write to
+  - `checkForLowDiskSpace` - Checks if the amount of disk space remaining is less than 64MiB
+- `net.minecraft.world.level.storage.LevelSummary#canUpload` - Returns whether the current level summary can be uploaded in a realm
+- `net.minecraft.world.level.storage.loot.ContainerComponentManipulator` - A helper for setting container contents for items in their data components
+  - A list of available manipulators can be found in `ContainerComponentManipulators`
+- `net.minecraft.world.level.storage.loot.functions.ListOperation` - Defines an operation that can be performed on a list
+- `net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction#getType` - Gets the item function type that can be conditionally loaded
+- `net.minecraft.world.phys.shapes.BitSetDiscreteVoxelShape#isInterior` - Checks whether the position is surrounded by fully encompassing shapes on all sides
+- `net.minecraft.client.gui.font.providers.FreeTypeUtil#checkError` - Returns true if an error was found
+- `net.minecraft.client.gui.screens.Screen`
+  - `advancePanoramaTime` - Updates the panorama by a set interval every frame
+    - Does not use the delta time frame provided in `renderPanorama`
+  - `clearTooltipForNextRenderPass` - Clears the tooltip rendering data 
+- `net.minecraft.nbt.CompoundTag#shallowCopy` - Creates a shallow copy of the tag
+- `net.minecraft.network.protocol.PacketUtils#makeReportedException` - Fills the crash report before returning the reported exception to throw
+- `net.minecraft.server.packs.repository.PackRepository#displayPackList` - Collects all packs into a single string by their id
+- `net.minecraft.world.item.crafting.RecipeManager#getOrderedRecipes` - Gets all recipes ordered by their `RecipeType`
+- `net.minecraft.world.level.chunk.ChunkGenerator#validate` - Resolves the feature step data to generate
+
+### Changes
+
+- `com.mojang.blaze3d.font.SheetGlyphInfo`
+  - `getBearingX` -> `getBearingLeft`
+  - `getBearingY` -> `getBearingTop`
+  - `getUp` -> `getTop`
+  - `getDown` -> `getBottom`
+- `com.mojang.blaze3d.font.TrueTypeGlyphProvider` now uses `org.lwjgl.util.freetype` over `org.lwjgl.stb` for font data storage
+- `com.mojang.blaze3d.platform.NativeImage#copyFromFont` -> `(FT_Face, int)`
+  - This method also returns a boolean, indicating whether the operation was successful
+- `com.mojang.blaze3d.systems.RenderSystem#getModelViewStack` now returns a `Matrix4fStack`
+- `com.mojang.blaze3d.vertex.PoseStack#mulPoseMatrix` -> `#mulPose`
+- `com.mojang.blaze3d.vertex.SheetedDecalTextureGenerator` now takes in a `PoseStack$Pose`
+- `com.mojang.blaze3d.vertex.VertexConsumer#putBulkData` now takes in the alpha parameter for the color
+- `net.minecraft.Util#LINEAR_LOOKUP_THRESHOLD` is now public
+- `net.minecraft.advancements.Advancement#validate(ProblemReporter, LootDataResolver)` -> `validate(ProblemReporter, HolderGetter$Provider)`
+- `net.minecraft.advancements.AdvancementRewards$Builder#loot`, `addLootTable` now take in a `ResourceKey<LootTable>`
+- `net.minecraft.client.MouseHandler#turnPlayer` is now private
+- `net.minecraft.client.Options$FieldAccess#process(String, OptionInstance)` -> `Options$OptionAccess$process`
+- `net.minecraft.client.gui.components.AbstractSelectionList#renderList` -> `renderListItems`
+- `net.minecraft.client.gui.components.AbstractWidget#setTooltipDelay(int)` -> `setTooltipDelay(Duration)`
+- `net.minecraft.client.gui.components.ChatComponent
+  - `render` now takes in if the chat is focused as a boolean parameter
+  - `isChatFocused` is now public
+- `net.minecraft.client.gui.components.Checkbox#getBoxSize` is now public
+- `net.minecraft.client.gui.components.FocusableTextWidget` now takes in an integer representing the padding of the widget
+- `net.minecraft.client.gui.components.ObjectSelectionList$Entry#mouseClicked` returns true by default
+- `net.minecraft.client.gui.components.OptionList`
+  - The constructor now takes in a `OptionsSubScreen` containing the content height and header height
+  - `addSmall` can now take in a varargs of `OptionInstance`s, a list of widgets, or two widgets
+  - `getMouseOver` now holds an optional of `GuiEventListener`
+  - `$Entry` -> `$OptionEntry`, `$Entry` is now an abstracted form which takes in the widgets directly
+- `net.minecraft.client.gui.components.SpriteIconButton` now takes in a `Button$CreateNarration` object
+  - This has been updated for all subclasses and provided a builder option called `narration`
+- `net.minecraft.client.gui.components.Tooltip#setDelay`, `refreshTooltipForNextRenderPass`, `createTooltipPositioner` have been moved to `WidgetTooltipHolder`
+  - The holder is stored on an `AbstractWidget` and is final. The tooltip within is mutable
+- `net.minecraft.client.gui.components.debugchart.AbstractDebugChart` now takes in a `SampleStorage`, which is an interface to the old `SampleLogger` (now renamed `LocalSampleLogger`)
+- `net.minecraft.client.gui.screens.ChatScreen#handleChatInput` no longer returns anything
+- `net.minecraft.client.gui.screens.ConnectScreen#startConnecting` takes in the current `TransferState`
+- `net.minecraft.client.gui.screens.GenericDirtMessageScreen` -> `GenericMessageScreen`
+- `net.minecraft.client.gui.screens.OptionsSubScreen` now holds a `HeaderAndFooterLayout` to initialize widgets and reposition them
+  - `addTitle`, `addFooter` have been added, replacing specific `createTitle` and `createFooter` methods in other implementations
+- `net.minecraft.client.gui.screens.Screen#setTooltipForNextRenderPass` is now public
+- `net.minecraft.client.gui.screens.advancements.AdvancementsScreen` can hold the last screen the user has seen
+- `net.minecraft.client.gui.screens.inventory.InventoryScreen#renderEntityInInventory` now takes in a float for the scale parameter
+- `net.minecraft.client.gui.screens.worldselection.WorldCreationUiState`
+  - `setAllowCheats` -> `setAllowCommands`
+  - `isAllowCheats` -> `isAllowCommands`
+- `net.minecraft.client.gui.screens.worldselection.WorldOpenFlows`
+  - `checkForBackupAndLoad(String, Runnable)` -> `openWorld`
+  - `checkForBackupAndLoad(LevelStorageAccess, Runnable)` -> `openWorldLoadLevelData`
+  - `loadLevel` -> `openWorldLoadLevelStem`
+- `net.minecraft.client.multiplayer.ServerStatusPinger#pingServer` now takes in a runnable that runs on response from the pong packet
+- `net.minecraft.client.particle.FireworkParticles$SparkParticle#setFlicker` -> `setTwinkle`
+- `net.minecraft.client.player.inventory.Hotbar` holds a list of `Dynamic`s instead of the raw itemstack list
+- `net.minecraft.client.renderer.EffectInstance` now takes in a `ResourceProvider` instead of a `ResourceManager`
+  - `ResourceManager` implements `ResourceProvider`, so there is no major change in implementation
+- `net.minecraft.client.renderer.LevelRenderer#renderClouds` takes in a `Matrix4f` containing the pose to transform the clouds to the correct location
+- `net.minecraft.client.renderer.PanoramaRenderer#render(float, float)` -> `render(GuiGraphics, int, int, float, float)`
+- `net.minecraft.client.renderer.PostChain` now takes in a `ResourceProvider` instead of a `ResourceManager`
+  - `ResourceManager` implements `ResourceProvider`, so there is no major change in implementation
+- `net.minecraft.client.renderer.PostChain#addPass` now takes in a boolean which determines whether to use `GL_LINEAR` when true or `GL_NEAREST` when false
+- `net.minecraft.client.renderer.PostPass` now takes in a `ResourceProvider` instead of a `ResourceManager`
+  - `ResourceManager` implements `ResourceProvider`, so there is no major change in implementation
+- `net.minecraft.client.renderer.PostPass#getFilterMode`
+  - Either `GL_LINEAR` or `GL_NEAREST`
+- `net.minecraft.client.renderer.blockentity.SkullBlockRenderer#getRenderType(SkullBlock$Type, GameProfile)` -> `getRenderType(SkullBlock$Type, ResolvableProfile)`
+- `net.minecraft.client.renderer.entity.LivingEntityRenderer#setupRotations` now takes in a scale representing the float parameter
+- `net.minecraft.client.renderer.entity.ArrowRenderer#vertex` combines the `Matrix4f` and `Matrix3f` into a `PoseStack$Pose`
+- `net.minecraft.client.renderer.entity.EntityRenderer#renderNameTag` now takes in a float representing the partial tick
+- `net.minecraft.client.renderer.entity.layers.StrayClothingLayer` -> `SkeletonClothingLater`
+- `net.minecraft.client.renderer.item.ItemProperties#getProperty(Item, ResourceLocation)` -> `getProperty(ItemStack, ResourceLocation)`
+- `com.mojang.blaze3d.audio.OggAudioStream` replaced by `net.minecraft.client.sounds.FiniteAudioStream`, `FloatSampleSource`, `JOrbisAudioStream`
+- `net.minecraft.commands.CommandBuildContext` now implements `HolderLookup$Provider`, replacing `holderLookup` and `configurable`
+- `net.minecraft.commands.arguments.ComponentArgument` now takes in a `HolderLookup$Provider` when constructing a text component
+- `net.minecraft.commands.arguments.ParticleArgument#readParticle` takes in a `HolderLookup$Provider` instead of a `HolderLookup` specifically for particle types
+- `net.minecraft.commands.arguments.ResourceLocationArguments`
+  - `getPredicate` -> `ResourceOrIdArgument#getLootPredicate`
+  - `getItemModifier` -> `ResourceOrIdArgument#getLootModifier`
+- `net.minecraft.commands.arguments.StyleArgument` now takes in a `HolderLookup$Provider` when constructing a style, or `CommandBuildContext` when calling `style`
+- `net.minecraft.commands.arguments.item.ItemInput` no longer implements `Predicate<ItemStack>`
+- `net.minecraft.commands.functions.CommandFunction#instantiate` no longer takes in the generic object
+  - The generic object is now stored as an entry directly within the function itself (e.g. `MacroFunction`)
+- `net.minecraft.ccommands.functions.FunctionBuilder#addMacro` takes in the generic object
+- `net.minecraft.core.GlobalPos` is now a record, though there is no change in usage
+- `net.minecraft.core.HolderLookup` the below logic is now applied specifically for `$RegistryLookup`
+  - `filterElements` -> `HolderLookup$RegistryLookup#filterElements)
+  - `$Delegate` -> `HolderLookup$RegistryLookup$Delegate`
+- `net.minecraft.core.Registry#lifecycle(T)` -> `registrationInfo(ResourceKey<T>)`
+- `net.minecraft.core.RegistrySetBuilder#lookupFromMap` now takes in a `HolderOwner`
+- `net.minecraft.core.RegistrySetBuilder$CompositeOwner` -> `$UniversalOwner`
+  - This is not one to one, it is simply a replacement
+- `net.minecraft.core.WritableRegistry#register(ResourceKey, T, Lifecycle)` -> `register(ResourceKey, T, RegistrationInfo)`
+- `net.minecraft.core.dispenser.AbstractProjectileDispenseBehavior` -> `ProjectileDispenseBehavior`
+- `net.minecraft.data.DataProvider#saveStable` also takes in a `HolderLookup$Provider` to get the `RegistryOps` lookup context
+- Game test batches have been reimplemented. The logic is now split between `net.minecraft.gametest.framework.GameTestBatch`, `GameTestBatchFactory`, and `GameTestBatchListener`
+- `net.minecraft.gametest.framework.GameTestHelper#makeMockSurvivalPlayer`, `makeMockPlayer()` -> `makeMockPlayer(GameType)`
+- `net.minecraft.gametest.framework.GameTestListener#testPassed`, `testFailed` now take in a `GameTestRunner`
+- `net.minecraft.nbt.NbtUtils`
+  - `readBlockPos` now takes in a key for the int array within the `CompoundTag`
+  - `writeBlockPos` now returns an `IntArrayTag`
+- `net.minecraft.network.chat.ChatType#CODEC` -> `#DIRECT_CODEC`
+- `net.minecraft.network.chat.Component$Serializer` methods also take in a `HolderLookup$Provider`
+- `net.minecraft.network.syncher.EntityDataAccessor` is now a record
+- `net.minecraft.server.MinecraftServer`
+  - `logTickTime` replaced by `getTickTimeLogger`, `isTickTimeLoggingEnabled`
+  - `endMetricsRecordingTick` is now public
+- `net.minecraft.server.ReloadableServerResources#getLootData` replaced by `fullRegistries`
+- `net.minecraft.server.level` chunk-querying methods now return a `ChunkResult` instead of an `Either<ChunkAccess, ChunkHolder$ChunkLoadingFailure>`
+- `net.minecraft.server.players.PlayerList`
+  - `setAllowCheatsForAllPlayers` -> `setAllowCommandsForAllPlayers`
+  - `isAllowCheatsForAllPlayers` -> `isAllowCommandsForAllPlayers`
+- `net.minecraft.tags.TagNetworkSerialization#deserializeTagsFromNetwork` is now package-private
+- `net.minecraft.util.SampleLogger` -> `net.minecraft.util.debugchart.LocalSampleLogger`
+  - This is now an implementation of `SampleStorage`
+- `net.minecraft.util.profiling.jfr.JvmProfiler#onPacketReceived` `onPacketSent` now take in the `PacketType` instead of an integer.
+- `net.minecraft.util.profiling.jfr.stats.NetworkPacketSummary` -> `IoSummary`
+- `net.minecraft.util.random.WeightedEntry$Wrapper` is now a record
+- `net.minecraft.world.Container#stillValidBlockEntity` now takes in a float representing the radius past the block interaction distance to check whether the block entity can be interacted with
+- `net.minecraft.world.ContainerHelper#saveAllItems`, `loadAllItems` now take in a `HolderLookup$Provider`
+- `net.minecraft.world.InteractionResult#shouldAwardStats` -> `indicateItemUse`
+- `net.minecraft.world.LockCode` is now a record
+- `net.minecraft.world.RandomizableContainer#getLootTable`, `setLootTable`, `setBlockEntityLootTable` take in a `ResourceKey<LootTable>` instead of a `ResourceLocation`
+- `net.minecraft.world.SimpleContainer#fromTag`, `createTag` now take in a `HolderLookup$Provider`
+- `net.minecraft.world.damagesource.CombatRules#getDamageAfterAbsorb` now takes in a `DamageSource` to calculate armor breach
+- `net.minecraft.world.effect.MobEffect`
+  - `applyEffectTick` now returns a boolean that, when false, will remove the effect if `shouldApplyEffectTickThisTick` returns true
+  - `createFactorData`, `setFactorDataFactory` has been replaced by `getBlendDurationTicks`, `setBlendDuration`
+  - `getAttributeModifiers` is replaced by `createModifiers`
+- `net.minecraft.world.effect.MobEffectInstance$FactorData` has been replaced by `$BlendState` along with the logic to apply
+- `net.minecraft.world.entity.AreaEffectCloud#setPotion` -> `setPotionContents`
+- `net.minecraft.world.entity.Entity` now implement `SyncedDataHolder` to handle network communication for entity properties
+  - `defineSynchedData` now takes in a `SynchedEntityData$Builder`
+  - `setSecondsOnFire` -> `igniteForSeconds`
+    - There is also an `igniteForTicks` variant
+  - `calculateViewVector` is now public
+  - `getMyRidingOffset`, `ridingOffset` -> `getVehicleAttachmentPoint`
+  - `getPassengerAttachmentPoint` now returns a `Vec3`
+  - `getHandSlots`, `getArmorSlots`, `getAllSlots`, `setItemSlot` are no longer on `Entity`, but still on `LivingEntity`
+  - `getEyeHeight` is now final and reads from the entity's dimensions
+    - Eye height is set through `EntityType$Builder`
+  - `getNameTagOffsetY` is now replaced by an `EntityAttachment`
+  - `getFeetBlockState` -> `getInBlockState`
+- `net.minecraft.world.entity.EntityDimensions` is now a record
+- `net.minecraft.world.entity.EntityType`
+  - `spawn`, `create` now takes in a `Consumer` of the entity to spawn rather than a `CompoundTag`
+  - `updateCusutomEntityTag` now takes in a `CustomData` object instead of a `CompoundTag`
+  - `getDefaultLootTable` now returns a `ResourceKey<LootTable>`
+  - `getAABB` -> `getSpawnAABB`
+- `net.minecraft.world.entity.LivingEntity`
+  - `getScale` -> `getAgeScale`
+    - `getScale` still exists and handles scaling based on an attribute property
+- `net.minecraft.world.entity.Mob#finalizeSpawn` no longer takes in a `CompoundTag`
+- `net.minecraft.world.entity.SpawnPlacements$Type` -> `SpawnPlacementsType`
+  - All `SpawnPlacementType`s are in `SpawnPlacementTypes`
+- `net.minecraft.world.entity.TamableAnimal`
+  - `setTame` now takes in a second boolean that, when true, applies any side effects from taming
+  - `reassessTameGoals` -> `applyTamingSideEffects`
+- `net.minecraft.world.entity.ai.attributes.AttributeInstance`
+  - `getModifiers` is now package-private
+  - `removeModifier` is now public
+- `net.minecraft.world.entity.ai.attributes.AttributeModifier` is now a record
+  - `$Operation`
+    - `ADDITION` -> `ADD_VALUE`
+    - `MULTIPLY_BASE` -> `ADD_MULTIPLIED_BASE`
+    - `MULTIPLY_TOTAL` -> `ADD_MULTIPLIED_TOTAL`
+- `net.minecraft.world.entity.ai.behavior.BehaviorUtils#lockGazeAndWalkToEachOther` now takes in an integer representing the close enough distance
+- `net.minecraft.world.entity.ai.village.poi.PoiManager` now takes in a `RegionStorageInfo`
+- `net.minecraft.world.entity.animal.Animal#isFood` is now abstract
+- `net.minecraft.world.entity.player.Player`
+  - `disableShield` no longer takes in a boolean
+  - `getPickRange` -> `blockInteractionRange`, `entityInteractionRange`
+- `net.minecraft.world.entity.projectile.AbstractArrow#deflect` -> `Entity#deflection`
+- `net.minecraft.world.entity.raid.Raid`
+  - `getMaxBadOmenLevel` -> `getMaxRaidOmenLevel`
+  - `getBadOmenLevel` -> `getRaidOmenLevel`
+  - `setBadOmenLevel` -> `setRaidOmenLevel`
+  - `absorbBadOmen` -> `absorbRaidOmen` and returns whether the entity has the effect
+  - `getLeaderBannerInstance` now takes in a `HolderGetter<BannerPattern>`
+- `net.minecraft.world.entity.raid.Raids#createOrExtendRaid` now takes in a `BlockPos` the raid is centered around
+- `net.minecraft.world.food.FoodData#eat` no longer takes in an `Item`
+- `net.minecraft.world.food.FoodProperties` is now a record
+  - `fastFood` has been replaced by a `eatSeconds` float representing time
+  - `Builder$saturationMod` -> `saturationModifier`
+  - `Builder$alwaysEat` -> `alwaysEdible`
+  - `Builder$meat` has been replaced with item tags for the given entity (e.g., `minecraft:wolf_food`
+- `net.minecraft.world.inventory.tooltip.BundleTooltip` stores its information within `BundleContents` via `#contents`
+- `net.minecraft.world.item.AdventureModeCheck` -> `AdventureModePredicate`
+- `net.minecraft.world.item.ArmorMaterial` is now a record
+  - `getDurabilityForType` -> `ArmorItem$Type#getDurability`
+  - `getDefenseForType` -> `defense`
+- `net.minecraft.world.item.AxeItem` is now public
+- `net.minecraft.world.item.CrossbowItem#performShooting` is now an instance method
+- `net.minecraft.world.item.HoeItem` is now public
+- `net.minecraft.world.item.Item`
+  - `verifyTagAfterLoad` -> `verifyComponentsAfterLoad`
+  - `getMaxStackSize` -> `ItemStack#getMaxStackSize`
+  - `getMaxDamage` -> `ItemStack#getMaxDamage`
+  - `canBeDepleted` -> `ItemStack#isDamageableItem`
+  - `isCorrectToolForDrops` now takes in an `ItemStack`
+  - `appendHoverText` holds an `Item$TooltipContext` instead of a `Level`
+  - `getDefaultAttributeModifiers` now returns an `ItemAttributeModifiers`
+  -  `canBeHurtBy` -> `ItemStack#canBeHurtBy`
+- `net.minecraft.world.item.ItemStack` now implements `DataComponentHolder`
+  - The constructor takes in a `DataComponentPatch` or `PatchedDataComponentMap` instead of a `CompoundTag`
+  - `save(CompoundTag)` -> `save(HolderLookup$Provider, Tag)`
+  - `hurt` -> `hurtAndBreak`
+    - A `Runnable` is the last parameter which determines what to do when a stack exceeds the max damage
+  - `hurtAndBreak(int, T, Consumer<T>)` -> `hurtAndBreak(int, LivingEntity, EquipmentSlot)`
+  - `isSameItemSameTags` -> `isSameItemSameComponents`
+  - `getTooltipLines(Player, TooltipFlag)` -> `getTooltipLines(Item$TooltipContext, Player, TooltipFlag)`
+  - `hasAdventureModePlaceTagForBlock` -> `canPlaceOnBlockInAdventureMode`
+  - `hasAdventureModeBreakTagForBlock` -> `canBreakBlockInAdventureMode`
+- `net.minecraft.world.item.ItemStackLinkedSet#createTypeAndTagSet` -> `createTypeAndComponentsSet`
+- `net.minecraft.world.item.ItemUtils#onContainerDestroyed` now takes a `Iterable<ItemStack>` instead of a `Stream<ItemStack>`
+- `net.minecraft.world.item.SmithingTemplateItem#createArmorTrimTemplate` takes in a varargs of `FeatureFlag`s
+- `net.minecraft.world.item.SpawnEggItem#spawnsEntity`, `getType` now takes in an `ItemStack` instead of a `CompoundTag`
+- `net.minecraft.world.item.alchemy.Potion#getName` now takes in an `Optional<Holder<Potion>>`
+- `net.minecraft.world.item.alchemny.PotionUtils` -> `PotionContents`
+  - Method names are roughly equivalent, ignorning all instances where a tag is wanted
+- `net.minecraft.world.item.armortrim.ArmorTrim` now takes in a boolean indicating whether the tooltip component will show up
+  - This tooltip can be toggled via `withTooltip`
+- `net.minecraft.world.item.crafting.Recipe`
+  - `assemble(C, RegistryAccess)` -> `assemble(C, HolderLookup.Provider)`
+  - `getResultItem(RegistryAccess)` -> `getResultItem(HolderLookup.Provider)`
+- `net.minecraft.world.item.crafting.RecipeCache#get` now returns a `Optional<RecipeHolder<CraftingRecipe>>`
+- `net.minecraft.world.item.crafting.RecipeManager`
+  - `getRecipeFor(RecipeType<T>, C, Level, ResourceLocation)` now returns an `Optional<RecipeHolder<T>>`
+    - The `RecipeHolder` contains the `ResourceLocation`
+  - `byType` now returns a `Collection<RecipeHolder` instead of a `Map<ResourceLocation, RecipeHolder<T>>`
+- `net.minecraft.world.item.traiding.MerchantOffer` now takes in `ItemCost`s for cost stack instead of `ItemStack`s
+- `net.minecraft.world.level.BaseCommandBlock#setName` -> `setCustomName`
+- `net.minecraft.world.level.Level`
+  - `getMapData`, `setMapData`, `getFreeMapId` now take in a `MapId` instead of an integer
+  - `createFireworks` now takes in a `List<FireworkExplosion>` instead of a `CompoundTag`
+- `net.minecraft.world.level.SpawnData` now takes in an `EquipmentTable`, which contains the armor an entity should spawn with
+- `net.minecraft.world.level.StructureManager`
+  - `getStructureWithPiecesAt` now takes in some set of `Sturcture`s
+  - `checkStructurePresence` now takes in a `StructurePlacement`
+- `net.minecraft.world.level.block.Block#appendHoverText` now takes in an `Item$TooltipContext` instead of a `BlockGetter`
+- `net.minecraft.world.level.block.EnchantmentTableBlock` -> `EnchantingTableBlock`
+- `net.minecraft.world.level.block.FlowerBlock` now takes in a `SuspiciousStewEffects`
+- `net.minecraft.world.level.block.entity.BeehiveBlockEntity`
+  - `addOccupantWithPresetTicks` -> `addOccupant`
+  - `storeBee(CompoundTag, int, boolean)` -> `storeBee(BeehiveBlockEntity$Occupant)`
+- `net.minecraft.world.level.block.entity.BlockEntity`
+  - `load` -> `loadAdditional`
+  - `saveAdditional`, `saveWithFullMetadata`, `saveWithId`, `saveWithoutMetadata`, `saveToItem`, `loadStatic`, `getUpdateTag` now takes in a `HolderLookup$Provider`
+- `net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity`
+  - `getItems` -> `BaseContainerBlockEntity#getItems`
+  - `setItems` -> `BaseContainerBlockEntity#setItems`
+- `net.minecraft.world.level.block.entity.trialspawner.PlayerDetector#detect(ServerLevel, BlockPos, int)` -> `detect(ServerLevel, PlayerDetector$EntitySelector, BlockPos, double, boolean)`
+- `net.minecraft.world.level.block.state.StateHolder#getValues` now returns a regular `Map` as it stores an `Reference2ObjectArrayMap`
+- `net.minecraft.world.level.chunk.ChunkAccess#getBlockEntityNbtForSaving` now takes in a `HolderLookup$Provider`
+- `net.minecraft.world.level.chunk.ChunkStatus` -> `net.minecraft.world.level.chunk.status.ChunkStatus`
+  - Some other classes that were inner classes have also been moved to the `net.minecraft.world.level.chunk.status` package (e.g. `ChunkType`)
+- `net.minecraft.world.level.gameevent.GameEvent` is now a record`
+- `net.minecraft.world.level.gameevent.GameEventListener$Holder` -> `GameEventListener$Provider`
+- `net.minecraft.world.level.levelgen.WorldDimensions(Map<ResourceKey<LevelStem>, LevelStem>)` is the new base constructor, the previous constructor with the `Registry` still exists
+- `net.minecraft.world.level.levegen.presets.WorldPreset#createRegistry` -> `dimensionsInOrder`
+- `net.minecraft.world.level.levelgen.structure.StructureCheck#checkStart` now takes in a `StructurePlacement`
+- `net.minecraft.world.level.levelgen.structure.StructurePiece#createChest` now takes in a `ResourceKey<LootTable>` instead of a `ResourceLocation`
+- `net.minecraft.world.level.levelgen.structure.StructurePiece#createDispenser` now takes in a `ResourceKey<LootTable>` instead of a `ResourceLocation`
+- `net.minecraft.world.level.pathfinder.BlockPathTypes` -> `PathType`
+- `net.minecraft.world.level.pathfinder.NodeEvaluator`
+  - `getGoal` -> `getTarget`
+  - `getTargetFromNode` -> `getTargetNodeAt`
+    - Gets the node based on a position rather than supplying the node itself
+  - `BlockPathTypes getBlockPathType(BlockGetter, int, int, int, Mob)` -> `PathType getPathTypeOfMob(PathfindingContext, int, int, int, Mob)`
+  - `BlockPathTypes getBlockPathType(BlockGetter, int, int, int)` -> `PathType getPathType(PathfindingContext, int, int, int)`
+- `net.minecraft.world.level.pathfinder.SwimNodeEvaluator`
+  - `isDiagonalNodeValid` -> `hasMalus`
+  - `getCachedBlockType` returns `PathType`
+- `net.minecraft.world.level.pathfinder.WalkNodeEvaluator`
+  - `isDiagonalValid` removes the accepted node value, only returning whether the diagonal can be made
+    - Checking the accepted node has been moved to a separate `isDiagonalValid(Node)` method
+  - `getBlockPathTypes`, `evaluateBlockPathType` -> `getPathTypeWithinMobBB`
+  - `getCachedBlockType` -> `getCachedPathType`
+  - `getBlockPathTypeStatic` -> `getPathTypeStatic`
+  - `checkNeighbourBlocks(BlockGetter, BlockPos$MutableBlockPos, BlockPathTypes)` -> `checkNeighbourBlocks(PathfindingContext, int, int, int, PathType)`
+  - `getBlockPathTypeRaw` -> `getPathTypeFromState`
+  - `isBurningBlock` -> `NodeEvaluator#isBurningBlock`
+- `net.minecraft.world.level.saveddata.SavedData`
+  - `save(CompoundTag)` -> `save(CompoundTag, HolderLookup.Provider)`
+  - `save(File)` -> `save(File, HolderLookup.Provider)`
+  - `$Factory(Supplier<T>, Function<CompoundTag, T>, DataFixTypes)` -> `$Factory(Supplier<T>, BiFunction<CompoundTag, HolderLookup.Provider, T>, DataFixTypes)`
+- `net.minecraft.world.level.saveddata.maps.MapBanner` is now a record
+- `net.minecraft.world.levle.saveddata.maps.MapDecoration$Type` -> `MapDecorationType`
+  - `MapDecorationType` is now a built-in registry object
+- `net.minecraft.world.level.storage.LevelData#getXSpawn`, `getYSpawn`, `getZSpawn` -> `getSpawnPos`
+- `net.minecraft.world.level.storage.LevelSummary#hasCheats` -> `hasCommands`
+- `net.minecraft.world.level.storage.ServerLevelData#getAllowCommands` -> `isAllowCommands`
+- `net.minecraft.world.level.storage.WorldData#getAllowCommands` -> `isAllowCommands`
+- `net.minecraft.world.level.storage.WritableLevelData#setXSpawn`, `setYSpawn`, `setZSpawn`, `setSpawnAngle` -> `setSpawn`
+- `net.minecraft.world.level.storage.loot.LootContext` now takes in a `HolderGetter$Provider`
+  - `getResolver` now returns the `HolderGetter$Provider`
+- `net.minecraft.world.level.storage.loot.LootDataType` is now a record
+- `net.minecraft.world.level.storage.loot.entries.LootTableReference` -> `NestedLootTable`
+- `net.minecraft.world.ticks.ContainerSingleItem#getContainerBlockEntity` -> `$BlockContainerSingleItem#getContainerBlockEntity`
+- `net.minecraft.client.Minecraft#setLevel(ClientLevel)` -> `setLevel(ClientLevel, ReceivingLevelScreen$Reason)`
+- `net.minecraft.client.OptionInstance$IntRange` now takes in a boolean that applies the option change immediately instead of after 0.6 seconds. The value is not considered saved at that moment when applied immediately
+- `net.minecraft.client.gui.font.providers.FreeTypeUtil#checkError` -> `assertError`
+  - `checkError` is now a boolean-returning method that doesn't throw an error
+- `net.minecraft.core.particles.DustParticleOptionsBase` -> `ScalableParticleOptionsBase`
+- `net.minecraft.nbt.CompoundTag#entries` -> `entrySet`
+  - This is a logic replacement, the returns are similar to those of a `Map`
+- `net.minecraft.network.PacketListener#shouldPropagateHandlingExceptions` -> `onPacketError`
+  - This is a logic replacement as the new method simply decides how to handle the error
+
+### Removals
+
+- `com.mojang.blaze3d.systems.RenderSystem#inverseViewRotationMatrix` along with subsequent getters and setters
+- `net.minecraft.client.Minecraft#is64Bit`
+- `net.minecraft.client.gui.components.AbstractSelectionList#setRenderBackground`
+- `net.minecraft.client.gui.components.DebugScreenOverlay#logTickDuration`
+- `net.minecraft.client.gui.font.FontManager#setRenames`, `getActualId`
+- `net.minecraft.client.gui.screens.MenuScreen#create` no longer checks nullability of `MenuType`
+- `net.minecraft.client.gui.screens.Screen#hideWidgets`
+- `net.minecraft.client.gui.screens.achievement.StatsUpdateListener`
+- `net.minecraft.client.gui.screens.worldselection.WorldOpenFlows#loadBundledResourcePack`
+- `net.minecraft.client.multiplayer.ClientLevel#setScoreboard`
+- `net.minecraft.client.multiplater.MultiPlayerGameMode`
+  - `getPickRange`
+  - `hasFarPickRange`
+- `net.minecraft.client.multiplayer.ServerData`
+  - `setEnforcesSecureChat`
+  - `enforcesSecureChat`
+- `net.minecraft.client.renderer.GameRenderer`
+  - `cycleEffect`
+  - `getPositionTexColorNormalShader`
+  - `getPositionTexLightmapColorShader`
+- `net.minecraft.commands.arguments.ArgumentSignatures#get`
+- `net.minecraft.core.RegistryCodecs`
+  - `withNameAndId`
+  - `networkCodec`
+  - `fullCodec`
+  - `$RegistryEntry`
+- `net.minecraft.core.dispenser.DispenseItemBehavior#getEntityPokingOutOfBlockPos`
+- `net.minecraft.server.level.ChunkHolder#getFullChunk`
+- `net.minecraft.util.JavaOps`
+- `net.minecraft.world.effect.AttributeModifierTemplate`
+- `net.minecraft.world.entity.Entity#setMaxUpStep`
+- `net.minecraft.world.entity.LivingEntity`
+  - `getMobType`
+  - `getEyeHeight`, `getStandingEyeHeight`
+- `net.minecraft.world.entity.MobType`
+- `net.minecraft.world.entity.ai.goal.GoalSelector`
+  - `getRunningGoals`
+  - `setNewGoalRate`
+- `net.minecraft.world.entity.player.Player#isValidUsername`
+- `net.minecraft.world.entity.projectile.ThrowableItemProjectile#getItemRaw`
+- `net.minecraft.world.item.BlockItem#getBlockEntityData`
+- `net.minecraft.world.item.Vanishable`
+- `net.minecraft.world.item.DyeableArmorItem`
+- `net.minecraft.world.item.DyeableHorseArmorItem`
+- `net.minecraft.world.item.DyeableLeatherItem`
+- `net.minecraft.world.item.EnchantedGoldenAppleItem`
+- `net.minecraft.world.item.FireworkStarItem#appendHoverText(CompoundTag, List<Component>)`
+- `net.minecraft.world.item.HorseArmorItem`
+- `net.minecraft.world.item.Item`
+  - `shouldOverrideMultiplayerNbt`
+  - `getRarity`
+  - `isEdible`
+  - `getFoodProperties`
+  - `isFireResistant`
+- `net.minecraft.world.item.ItemStack`
+  - `of`
+  - `hasTag`
+  - `getTag`
+  - `getOrCreateTag`
+  - `getOrCreateTagElement`
+  - `getTagElement`
+  - `removeTagKey`
+  - `getEnchantmentTags`
+  - `setTag`
+  - `setHoverName`
+  - `hasCustomHoverName`
+  - `addTagElement`
+  - `getBaseRepairCost`
+  - `setRepairCost`
+  - `getAttributeModifiers`
+  - `isEdible`
+  - `$TooltipPart`
+- `net.minecraft.world.item.SuspiciousStewItem`
+  - `saveMobEffects`
+  - `appendMobEffects`
+  - `listPotionEffects`
+- `net.minecraft.world.item.armortrim.ArmorTrim`
+  - `setTrim`
+  - `getTrim`
+  - `appendUpgradeHoverText`
+- `net.minecraft.world.item.crafting.Ingredient`
+  - `toNetwork`
+  - `fromNetwork`
+- `net.minecraft.world.level.Level#dimensionTypeId`
+- `net.minecraft.world.level.NaturalSpawner#isSpawnPositionOk`
+- `net.minecraft.world.level.block.entity.BaseContainerBlockEntity#setCustomName`
+- `net.minecraft.world.level.block.entity.BeehiveBlockEntity#addOccupant`
+- `net.minecraft.world.level.storage.loot.LootDataId`
+  - Basically a `ResourceKey`
+- `net.minecraft.world.level.storage.loot.LootDataManager`
+  - Basically a `HolderGetter$Provider`
+- `net.minecraft.world.level.storage.loot.LootDataResolver`

--- a/primers/1.20.6/index.md
+++ b/primers/1.20.6/index.md
@@ -1,0 +1,16 @@
+# Minecraft 1.20.5 -> 1.20.6 Mod Mini Primer
+
+This is a high level, non-exhaustive overview on the minor changes from 1.20.5 to 1.20.6. This does not look at any specific mod loader, just the changes to the vanilla classes.
+
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Pack Changes
+
+There are a number of user-facing changes that are part of vanilla which are not discussed below that may be relevant to modders. You can find a list of them on [Misode's version changelog](https://misode.github.io/versions/?id=1.20.6&tab=changelog).
+
+## Additions
+
+- `net.minecraft.world.level.block.entity.BlockEntity#parseCustomNameSafe` - Attempts to serialize a string into a `Component`. On failure, `null` is returned

--- a/primers/1.20.6/index.md
+++ b/primers/1.20.6/index.md
@@ -5,7 +5,7 @@ This is a high level, non-exhaustive overview on the minor changes from 1.20.5 t
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Pack Changes
 

--- a/primers/1.20/forge.md
+++ b/primers/1.20/forge.md
@@ -1,0 +1,94 @@
+# Minecraft 1.19.4 -> 1.20 Forge Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.19.4 to 1.20 using Forge.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Vanilla Changes
+
+Vanilla changes are listed [here](./index.md).
+
+## Creative Tab Registry
+
+Nw tabs can be registered using one of the register methods while adding to existing tabs is done via `BuildCreativeModeTabContentsEvent` on the mod event bus. For new tabs, Forge patches in the ability to order tabs via `CreativeModeTab$Builder#withTabsBefore` and `#withTabsAfter`.
+
+```java
+// Registered on the MOD event bus
+// Assume we have RegistryObject<Item> and RegistryObject<Block> called ITEM and BLOCK
+@SubscribeEvent
+public void buildContents(BuildCreativeModeTabContentsEvent event) {
+    // Add to ingredients tab
+    if (event.getTabKey() == CreativeModeTabs.INGREDIENTS) {
+        event.accept(ITEM);
+        event.accept(BLOCK); // Takes in an ItemLike, assumes block has registered item
+    }
+}
+```
+
+## Forge Config: Resource Pack Caching Removal
+
+All entries related to resource pack caching were removed from the Forge common config. Vanilla now handles this by default.
+
+## Forge Capability Class Removals
+
+The `Capability*` which originally held the Forge capabilities have been removed. All calls should be delegated to `ForgeCapabilities` instead.
+
+## Forge Network Message Consumers
+
+Within the message builder for Forge networks, the `#consumer`, which handles the message logic, has been removed. Now, it has been broken into `#consumerNetworkThread` and `#consumerMainThread`. These methods determine whether the logic should be handled directly on the network thread or delegated to the consumer itself.
+
+`#consumerMainThread` handles the packet for you, so it only accepts a `BiConsumer`.
+
+```java
+public void mainThreadMessage(MSG message, Supplier<NetworkEvent.Context> ctx) { /**/ }
+```
+
+`#consumerNetworkThread` can take in a `BiConsumer` or `ToBooleanBiFunction` depending on if you want to handle the packet via `#setPacketHandled` or using the return statement, respectively.
+
+```java
+public void networkThreadMessageC(MSG message, Supplier<NetworkEvent.Context> ctx) { 
+    // ...
+    ctx.get().setPacketHandled(true);
+}
+
+public boolean networkThreadMessageF(MSG message, Supplier<NetworkEvent.Context> ctx) { 
+    // ...
+    return true;
+}
+```
+
+## Removal of Dummy Entries
+
+Forge dummy entries handled by Forge registries have been completely removed.
+
+## New Tags
+
+* Item Tag `forge:tools/swords` -> `minecraft:swords`
+* Item Tag `forge:tools/axes` -> `minecraft:axes`
+* Item Tag `forge:tools/pickaxes` -> `minecraft:pickaxes`
+* Item Tag `forge:tools/shovels` -> `minecraft:shovels`
+* Item Tag `forge:tools/hoes` -> `minecraft:hoes`
+
+## Minor Changes and Renames
+
+* `net.minecraftforge.event.entity.player.PlayerEvent$BreakSpeed#getPos` -> `#getPosition` which now takes in an `Optional<BlockPos>`
+* `net.minecraftforge.client.event.RenderLevelLastEvent` -> `RenderLevelStageEvent`
+    * There is no direct translation between the events. You need to choose which stage suits your logic best.
+* `net.miencraftforge.common.world.ModifiableBiomeInfo$BiomeInfo$Builder#getEffects` -> `#getSpecialEffects`
+* `net.miencraftforge.client.extensions.IForgeTransformation#push` -> `IForgePoseStack#pushTransformation`
+* `net.minecraftforge.client.event.RegisterParticleProvidersEvent#register` -> `#registerSpecial`, `#registerSprite`, `#registerSpriteSet` respectively
+* `net.minecraftforge.common.extensions.IForgePlayer#getAttackRange` -> `#getEntityReach`
+    * `ForgeMod#REACH_DISTANCE` -> `#BLOCK_REACH`
+* `net.minecraftforge.common.extensions.IForgePlayer#getReachDistance` -> `#getBlockReach`
+    * `ForgeMod#ATTACK_RANGE` -> `#ENTITY_REACH`
+* `net.minecraftforge.common.extensions.IForgePlayer#canHit` and `#canInteractWith` -> `#canReach`
+* `net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent` -> `LivingChangeTargetEvent`
+* `net.minecraftforge.client.model.generators.BlockModelBuilder#rootTransform` -> `#rootTransforms`
+    * All root transformation logic has been moved to `ModelBuilder` and `TransformationHelper`
+* `net.minecraftforge.common.extensions.IForgeItem#onUsingTick` -> `Item#onUseTick`
+* `net.minecraftforge.event.level.SaplingGrowTreeEvent` -> `BlockGrowFeatureEvent`
+* `net.minecraftforge.client.model.IQuadTransformer#empty`, `#applying`, and `#applyingLightmap` moved to `QuadTransformers`
+* `net.minecraftforge.client.gui.ScreenUtils` has all been moved to extension methods on `GuiGraphics`
+    * `#drawTexturedModalRect` and `#drawGradientRect` have been replaced with `#blit` and `#fillGradient`, respectively

--- a/primers/1.20/forge.md
+++ b/primers/1.20/forge.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Vanilla Changes
 

--- a/primers/1.20/index.md
+++ b/primers/1.20/index.md
@@ -1,0 +1,367 @@
+# Minecraft 1.19.4 -> 1.20 Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.19.4 to 1.20. This does not look at any specific mod loader, just the changes to the vanilla classes.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Pack Changes
+
+There are a number of user-facing changes that are part of vanilla which are not discussed below that may be relevant to modders. You can find a list of them on [Misode's version changelog](https://misode.github.io/versions/?id=1.20&tab=changelog).
+
+## Moving Experimental Features
+
+All experimental features which were disabled with the `update_1_20` flag are now moved to their proper locations and implementations. Removed features flags can be seen within `net.minecraft.world.level.storage.WorldData#getRemovedFeatureFlags`.
+
+## LootData
+
+Loot Tables, Predicates, and Item Modifiers have been internally migrated to be handled by one system: `LootData`. `LootData` is resolved using a `LootDataResolver` and identified through its `LootDataType`. In addition, a particular `ResourceLocation` can be associated with a `LootDataType` by wrapping it within a `LootDataId`.
+
+All calls to `#getLootTables`, `#getPredicateManager`, `#getItemModifierManager` have now been replaced with `#getLootData`. From there, you can grab the necesssary element using `#getElement` or `#getElementOptional`.
+
+```java
+// Given some MinecraftServer 'server'
+server.getLootData().getElement(LootDataType.TABLE, new ResourceLocation(MODID, "example_table"));
+```
+
+## Vertex Logic Changes
+
+Vertices within the projection matrix can now be sorted via `com.mojang.blaze3d.vertex.VertexSorting`. By default, sorting can occur either from the distance to the origin (`#DISTANCE_TO_ORIGIN`), by distance from the screen projection (`#ORTHOGRAPHIC_Z`) or by any distance function specified by the user (`#byDistance`). As an interface, this can be extended to encompass any implementation. This can be set via `RenderSystem#setProjectionMatrix`. 
+
+Some methods have been modified to accept a `VertexSorting`:
+
+* `com.mojang.blaze3d.vertex.BufferBuilder#setQuardSortOrigin` -> `#setQuadSorting`
+
+The `VertexBufffer` now takes in a `VertexBuffer$Usage` enum, which determines whether to use `GL_STATIC_DRAW` or `GL_DYNAMIC_DRAW`.
+
+## GuiGraphics
+
+`GuiComponent` has been fully removed from the game, now taking the form of `GuiGraphics`. `GuiGraphics`, as the name implies, holds all drawing related information and helpers for GUIs. Most `PoseStack` parameters within gui related classes have now been replaced with `GuiGraphics`. The `PoseStack` can still be obtained via `GuiGraphics#pose`. In addition, gui related drawing methods outside of `GuiComponent` have now been migrated to `GuiGraphics`, such as `ItemRenderer#renderGuiItem`. GUIs now have a Z-value (which indicates closeness to the camera) bounded at `[-10000, 10000]`.
+
+The internals of `GuiGraphics` now make it such that almost all `RenderSystem` calls are unnecessary. `RenderSystem#depthMask` and `#enable/disableDepthTest` calls are now handled using `GuiGraphics#flush` internally or by specifying a `RenderType` for rendering to the screen. Additionally, draw calls can be isolated using `GuiGraphics#drawManaged`, which flushes the buffer before and after the data has been drawn.
+
+This also created some new shards to use:
+* `RenderStateShard$ColorLogicStateShard` with `no_color_logic` and `or_reverse`
+
+There have been some removals as well:
+* `#blitOutlineBlack` - The only usecase in `LogoRenderer` was replaced with a texture containing the outline instead.
+
+## Light Engine Rewrite
+
+The light engine has been rewritten to be more efficient and consolidated. While the basic usages of the light engine remain similar, more complicated tasks will require some amount of rewriting.
+
+Most lighting related logic flows that were scattered outside of classes for handling lighting, like the light engine, were removed. In addition, lighting information stored and written outside of the light engine have also been removed.
+
+### LightEngine
+
+Let's start with `LightEngine`. This is essentially a rename of `LayerLightEngine` with more performant propogation logic when adding or removing a source. Most of the methods in this class are 1-to-1, with a few having their parameters changed in some capacity. `LightEngine` is implemented via `SkyLightEngine` and `BlockLightEngine` for sky and block light, respectively. As such, `net.minecraft.world.level.LightLayer` has been reduced to enum constants no longer holding the surrounding light layer value. Any on light increase/decrease methods within these classes have been removed in favor of callbacks within location methods for handling the propogation.
+
+Initialization of the light sources are now done through `#initializeLightSources` methods, like in `ChunkAccess`, during chunk loading and packets from the server.
+
+#### ChunkSkyLightSources
+
+`SkyLightEngine` now handles light sources within a chunk via the `ChunkSkyLightSources`. This essentially is a bit storage which handles how sky light propogates through the chunk downward.
+
+### LightChunk
+
+`LightChunk` is an interface that extends `BlockGetter` which all chunks implement. `LightChunk` contains two methods: `#findBlockLightSources`, which finds all blocks which emits light and passes into a callback which increases the light source at the position asynchronously, and `#getSkyLightSources`, which stores the `ChunkSkyLightSources` for the current chunk. This replaces the methods within `ChunkAccess` (e.g. `#getLights`).
+
+As such, all lighting related calls to a chunk, such as `LightChunkGetter#getChunkForLighting`, returns the `LightChunk`, instead of the `BlockGetter`.
+
+## RuleBlockEntityModifier
+
+Within the `rule` structure processor, block entities can now be streamlined for modification using a `RuleBlockEntityModifier`. These simply define how to modify the tag on a particular block entity. Vanilla provides an implementation to clear the tag (`clear`), merge the tag with another(`append_static`), add a loot tag (`append_loot`), or do nothing (`passthrough`). New modifiers can be added via a `RuleBlockEntityModifierType` using a static registry.
+
+## Signs: Now with More Features
+
+Signs now have a multitude of features. First, the sign text itself is stored within a `net.minecraft.world.level.block.entity.SignText` object. The text can be on both the front and back of the sign. Within `SignBlock`, it can now specify a full rotation using the abstract method `SignBlock#getYRotationDegrees`. Additionally, the sign editor can be opened via `#openTextEdit`. The hitbox center of the sign is determined via `SignBlock#getSignHitboxCenterPosition`. The sign's model and text can be scaled via `SignRenderer#getSignModelRenderScale` and `#getSignTextRenderScale` respectively.
+
+Signs can also be modified by items by attaching the `net.minecraft.world.item.SignApplicator` interface. First, it will check whether the item can be applied to the sign (`#canApplyToSign`) and then attempt to apply the data to the sign and return whether or not is was successful (`#tryApplyToSign`).
+
+Click commands on signs can now be toggled via `SignBlockEntity#canExecuteClickCommands`. This is currently only applied when attempting to chain hanging signs together.
+
+## Goodbye Legacy Smithing
+
+In 1.19.4, the current smithing implementation was deprecated and migrated to a legacy implementation to be replaced with transformers and trims. 1.20 removes the legacy implemenation in its entirety. These include classes like `LegacyUpgradeRecipe` and `LegacySmithingScreen`.
+
+## Redstone Signals via the SignalGetter
+
+All signal information originally tied to the level have been migrated into its own getter called `net.minecraft.world.level.SignalGetter`. If you are calling this directly from the `Level` itself, you will likely not notice any difference in `#getDirectSignalTo`, `#hasSignal`, `#getSignal`, `#hasNeighborSignal`, and `#getBestNeighborSignal`.
+
+There are, of course, a few changes within the `net.minecraft.world.level.block.DiodeBlock` itself:
+
+* `#getAlternateSignal(LevelReader, BlockPos, BlockState)` -> `#getAlternateSignal(SignalGetter, BlockPos, BlockState)`
+* `#getAlternateSignalAt` -> `SignalGetter#getControlInputSignal`
+* `#isAlternateInput` -> `#sideInputDiodesOnly`
+
+## Resonate Vibrations
+
+As 1.20 added in calibrated sculk sensors, vibrations listeners have been modified to handle different frequencies and allow some form of resonation with other blocks. This is typically checked via `net.minecraft.world.level.block.SculkSensorBlock#tryResonateVibration` which determines the resonance `GameEvent` to emit via `net.minecraft.world.level.gameevent.vibrations.VibrationSystem#getResonanceEventByFrequency`. Resonance for a particular block can be added via the `minecraft:vibration_resonators` block tag. Listeners can be attached to any entity using `VibrationSystem$Listener`.
+
+> Resonance is currently hardcoded to the sound of amethyst blocks.
+
+## StructureProcessor Redefinitions
+
+The two main methods within `StructureProcessor` have been slightly changed to redefine their implementations. First, `#processBlock` now no-ops to the passed in `StructureBlockInfo` instead of being an abstract method. Second, `#finalizeProcessing` now returs the modified list of `StructureBlockInfo`s, no-oping to the passed in list by default. `#finalizeProcessing` also now takes in the `ServerLevelAccessor` instead of just the `LevelAccessor`, similar to most other template logic calls.
+
+## Stripping Materials
+
+`Material`s have been completely removed from Block Properties. There are a number of changes reflecting this.
+
+Creating a block property is done through the static constructor `#of` which takes no arguments:
+
+```java
+// Other properties can be chained to the end of this
+BlockBehavior.Properties.of();
+```
+
+First, `BlockBehaviour#getPistonPushReaction(BlockState)`, `Material#getPushReaction`, `Material$Builder#destroyOnPush`, and `Material$Builder#notPushable` no longer exist, and is now set as a property via `BlockBehaviour$Properties#pushReaction`. In addition, a block is only flammable to lava if the `#ignitedByLava` property is called, replacing `Material#isFlammable` and `Material$Builder#flammable`. A block is also set has a liquid if it has the `#liquid` property, replacing `Material#isLiquid`. A block can be forced to be solid or not regardless of the shape using `BlockBehaviour$Properties#forceSolidOn` and `#forceSolidOff`, respectively. You can also set whether a block can be replaced via `#replaceable`.
+
+You can find a list of replacement properties for every material on [Gizmo's gist](https://gist.github.com/GizmoTheMoonPig/77a90a48e0aeecd15b4c524e1c7f0a4a).
+
+The sound a block makes when put underneath a note block is set using `BlockBehaviour$Properties#instrument`.
+
+`net.minecraft.world.level.material.MaterialColor`s have now been replaced with `MapColor`s. `MapColor`s can be specified on a block property using `#mapColor` (replaces `#color`) by specifying a `DyeColor`, `MapColor`, or a function converting a `BlockState` to a `MapColor`. This includes the following renames:
+
+* `net.minecraft.world.level.block.state.BlockBehavior#defaultMaterialColor` -> `#defaultMapColor`
+
+The following `BlockState` methods have been added:
+
+* `BlockState#blocksMotion`
+* `BlockState#isSolid`
+* `BlockState#instrument`
+
+## Criteria Changes
+
+All `AbstractCriterionTriggerInstance`s now take in a `ContextAwarePredicate` instead of a `EntityPredicate$Composite` representing teh player. `ContextAwarePredicate` is essentially a list of ANDed `LootItemCondition`s. While this is still representative of the player in most cases, `ItemUsedOnLocationTrigger`, which replaces `ItemInteractWithBlockTrigger` and `PlacedBlockTrigger`, uses the `ContextAwarePredicate` to perform changes based on the state of the block being targetted. `ContextAwarePredicate`s can be created using `#create` or `EntityPredicate#wrap` for easy compatibility with the player.
+
+## Creative Tab Registry
+
+`CreativeModeTab`s are now a new static registry.
+
+## Minor Additions, Changes, and Removals
+
+The following is a list of useful or interesting additions, changes, and removals that do not deserve their own section in the primer.
+
+### Suspicuous Sand to Brushable
+
+All suspicuous sand implementations have now been renamed to 'brushable' (e.g., `SuspiciousSandBlock` -> `BrushableBlock`).
+
+### ProjectileUtil#getHitResult
+
+`net.minecraft.world.entity.projectile.ProjectileUtil#getHitResult` has been expanded into two methods: `#getHitResultOnMoveVector`, which uses the vector from the entity's feet position and `#getHitResultOnViewVector` which uses the vector from the entity's eye position. `#getHitResultOnMoveVector` directly replaces `#getHitResult` in previous versions.
+
+### CommonInputs
+
+`net.minecraft.client.gui.navigation.CommonInputs` has been added to add convenience implementations related to inputs on GUIs. Currently, the only method is `#selected`, which checks whether the space or enter keys have been pressed.
+
+### Fonts
+
+The internals of fonts have changed quite a bit, though most user facing calls remain the same. `GlyphRenderTypes` now hold the font `RenderType`s for normal rendering, see through, or polygon offset. `CodepointMap`s, which are essentially an integer to object maps, are now being used within bitmap and unihex providers. The `FontManager` itself is now reloadble and managed via codecs rather than having a field which handles the logic instead.
+
+All classes with the name `Builder` have either had the `Builder` removed or replaced with `Definition` instead (e.g. `ProviderReferenceBuilder` -> `ProviderReferenceDefinition`).
+
+`GlyphProviderType#LEGACY_UNICODE` (renamed from `GlyphProviderBuilderType`) has now been removed in favor of the `#UNIHEX` implementation. Additionally, a `#REFERENCE` builder type was added which allows a user to reference a different font set definition using an `id` which references the `assets/<namespace>/font` directory.
+
+In addition, `net.minecraft.client.gui.Font#draw`, `#drawShadow`, `#drawWordWrap` have been removed. It is expected that these calls directly pass through `GuiGraphics` which have the ability to specify the parameters that these methods originally hardcoded.
+
+#### GlyphProviderDefinition
+
+`GlyphProviderBuilder` has been reorganized:
+
+* `net.minecraft.client.gui.font.providers.GlyphProviderBuilder#create` -> `GlyphProviderDefinition$Loader#load`
+    * This change also throws an `IOException` rather than returning a null entry.
+* `GlyphProviderDefinition#unpack` is now used to construct a loader for the font or a record holding a reference to the glyph provider to be loaded.
+
+### OR, AND, and Composite LootItemConditions
+
+The `AlternativeLootItemCondition`, or `alternative`, has been removed and split into two conditions: `any_of` or `all_of`, which represent an OR or AND, respectively. Additionally, composite conditions now have a separate, abstract superclass called `CompositeLootItemCondition`.
+
+### LootParams
+
+The implementation of `LootContext` has been split across itself and `LootParams`. `LootParams` is responsible for what `LootContext` used to do previously: the level, parameters, dynamic drops, and luck. In most instances, you can replace `LootContext` with `LootParams` when constructing the parameter logic. There are additional wrappers within` LootTable` which now take in a `LootParams` instead of the `LootContext` itself, using the stored random sequence. 
+
+`LootContext` now takes in a `LootParams` along with a random sequence responsible for handling the random selection. This will still be passed into loot tables for generating the required data. This also can specify an optional seed in case the `LootParams` does not have one. Some methods within `LootContext` now take in an additional long representing this optional seed (e.g., `#fill`).
+
+As such, following fields and methods have been changed:
+
+* `net.minecraft.world.level.block.state.BlockBehaviour#getDrops(BlockState, LootContext$Builder)` -> `#getDrops(BlockState, LootParams$Builder)`
+* `net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase#getDrops(LootContext$Builder)` -> `#getDrops(LootParams$Builder)`
+
+#### RandomSequence
+
+Each `LootContext` is now given a `XoroshiroRandomSource` based upon a unique `ResourceLocation` used to handle the random selection. This is stored within a `SavedData` and accessed via `ServerLevel#getRandomSequences`, or an individual `RandomSource` via `#getRandomSequence`. Currently, the only random source used is `LootTable#DEFAULT_RANDOM_SEQUENCE` (`minecraft:default`).
+
+### CropBlock Method Accessors
+
+The accessors of three methods in `CropBlock` have changed:
+
+* `#getAgeProperty` is now `protected` instead of `public`
+* `#getAge` is now `public` instead of `protected`
+* `#isMaxAge` is now `final`
+
+### CombatTracker Rework
+
+A lot of the logic and methods have been reworked or moved in the `CombatTracker`:
+
+* Changes
+    * `#recordDamage(DamageSource, float, float)` -> `#recordDamage(DamageSource, float)`
+    * `#getFallLocation` -> `FallLocation#getCurrentFallLocation`
+* Removals
+    * `#prepareForDamage`
+    * `#getKiller`
+    * `#isTakingDamage`
+    * `#isInCombat`
+    * `#resetPreparedStatus`
+    * `#getMob`
+    * `#getLastEntry`
+    * `#getKillerId`
+
+### New Tags
+
+* Biome Tag `minecraft:has_structure/trail_ruins`
+* Block Tag `minecraft:combination_step_sound_blocks` - For blocks that should play the step sound of the current block and the one below it
+* Block Tag `minecraft:vibration_resonators` - Determines whether sounds made on this block which cause vibrations should resonate.
+* Block Tag `minecraft:sniffer_egg_hatch_boost`- Determines whether the block beneath the sniffer egg speeds up the hatch time.
+* Block Tag `minecraft:trail_ruins_replaceable`
+* Block Tag `minecraft:sword_efficient` - Whether it is efficient to break this block with a sword
+* Block Tag `minecraft:replaceable_by_trees` - Determines whether the block can be replaced by trees
+* Block Tag `minecraft:replaceable` - Determines whether the block is replaceable
+    * This is likely the replacement for `minecraft:replaceable_plants`
+* Block Tag `minecraft:enchantment_power_provider` - Determines what can provide power to an enchantment table
+* Block Tag `minecraft:enchantment_power_transmitter` - Determines what can not obstruct the transmission of power to an enchantment table
+* Block and Item Tag `minecraft:stone_buttons`
+* Item Tag `minecraft:villager_plantable_seeds`
+* Item Tag `minecraft:decorated_pot_shards` -> `minecraft:decorated_pot_sherds`
+* Block Tag `minecraft:maintains_farmland` - Determines whether a block maintains the farmland beneath it
+* Item Tag `minecraft:decorated_pot_ingredients`
+
+### Additions
+
+* `net.minecraft.core.BlockPos#breadthFirstTraversal` - Traverses block positions from the distance of a sented point and determines whether how many positions meet the associated predicate.
+* `net.minecraft.util.ExtraCodecs#FLAT_COMPONENT` - Converts a `Component` to/from a string.
+* `net.minecraft.world.entity.Entity#handleStepSounds`, `#getPrimaryStepSoundBlockPos`, and `#playCombinationStepSounds` are used to handle block sounds that should be played at the same time when walking over them.
+* `net.minecraft.world.entity.animal.Animal#finalizeSpawnChildFromBreeding` - Handles any additional spawn settings from breeding the entity without spawning the child itself.
+* `net.minecraft.world.level.block.LeavesBlock#getOptionalDistanceAt` - Public facing implementation of `#getDistanceAt`
+* `net.minecraft.client.gui.screens.Screen#getBackgroundMusic` - Screens can set what background music to play when open
+    * Music that needs to be stopped on close should query the music manager (via `MusicManager#stopPlaying`) through `Screen#removed`
+* `net.minecraft.world.level.lighting.LeveledPriorityQueue` - A stacked priority queue
+* `net.minecraft.client.gui.components.AbstractWidget#getTooltip` - Returns the tooltip associated with a component
+* `net.minecraft.world.entity.Entity#getNameTagOffsetY` - The offset of the nametag's y position
+* `net.minecraft.world.item.ItemStack#copyAndClear` - Returns a copy of the item stack while clearing the original
+* `net.minecraft.world.level.block.DoorBlock#type` - Returns the door's `BlockSetType`
+* `net.minecraft.world.level.block.FarmableBlock` - Used to check whether a farmland should be kept for the above block
+* `net.minecraft.world.level.block.IceBlock#meltsInto` - Returns what the ice block should melt into
+* `net.minecraft.world.level.block.SculkSensorBlock#getActiveTick` - Returns how many ticks the sculk sensor should remain active for
+* `net.minecraft.world.inventory.CraftingContainer#getItems`
+* `net.minecraft.world.inventory.Slot#isHighlightable`
+* `com.mojang.blaze3d.platform.NativeImage#applyToAllPixels` - Applies a transformation to the colors of the pixels of an image
+* `net.minecraft.core.SectionPos#getZeroNode(II)` - Gets the zero node section position from a specified XZ coordinate.
+* `net.minecraft.util.DependencySorter` - Basic logic flow for sorting dependencies
+* `net.minecraft.util.ExtraCodecs#CODEPOINT`
+* `net.minecraft.world.entity.Mob#onPathfindingStart` and `#onPathfindingDone` - Callbacks for pathfinding
+* `net.minecraft.world.level.chunk.ChunkAccess#getHighestGeneratedStatus`
+* The telemetry system has been more flushed out with hooks into advancements and realms.
+* `net.minecraft.gametest.framework.GameTestHelper#withLowHealth`
+* `net.minecraft.network.syncher.SynchedEntityData#hasItem`
+* `net.minecraft.util.ExtraCodecs#validate` - General validator to apply to an `Codec#flatXmap`
+* An entity now keeps track of the blocks that are colliding, or 'supporting', the entity and preventing them from continuing to fall down. The 'supporting' block can be checked via `Entity#isSupportedBy`
+* `net.minecraft.advancements.Advancement$Builder#recipeAdvancement` - Constructs an advancement for a recipe and does not send a telemetry event.
+* `net.minecraft.Util#fixedSize(LongStream, I)`
+* `net.minecraft.gametest.framework.GameTestHelper#makeMockServerPlayerInLevel`
+* `net.minecraft.server.level.ChunkLevel` - A helper class for managing chunk statuses and loading states.
+* `net.minecraft.world.entity.Entity#setPortalCooldown(I)` and `#getPortalCooldown`
+* `net.minecraft.world.entity.LivingEntity#getLootTableSeed`
+* `net.minecraft.world.entity.boss.enderdragon.EnderDragon#setDragonFight`, `#setFightOrigin`, `#getFightOrigin`
+* `net.minecraft.world.level.levelgen.Xoroshiro*` classes now have codecs
+* `net.minecraft.Util#isWhitespace` and `#isBlank`
+    * Minecraft alternatives for `org.apache.commons.lang3.StringUtils`
+* `net.minecraft.client.model.HierarchicalModel#applyStatic` - Used to apply static transforms using the animation system
+* `net.minecraft.world.entity.Entity#isOnRails` - Currently only `true` for minecarts when on rails
+* `net.minecraft.world.item.crafting.Ingredient#fromJson(JsonElement, boolean)` - When the boolean is true, air will return a `null` ingredient instead of throwing an exception.
+    * This is the default in the `#fromJson(JsonElement)` overload
+* `net.minecraft.world.level.BaseCommandBlock#isValid` - Checks whether the command block menu can be accessed
+* `net.minecraft.client.gui.screens.FaviconTexture`
+* `net.minecraft.gametest.framework.GameTestHelper#killAllEntitiesOfClass`
+* `net.minecraft.gametest.framework.GameTestHelper#assertRedstoneSignal`
+* `net.minecraft.world.entity.Entity#setOnGroundWithKnownMovement` - Sets the user as being on the ground along with the block the entity plans to stand on.
+* `net.miencraft.world.level.block.EquipableCarvedPumpkinBlock`
+* `net.miencraft.world.level.levelgen.RandomSupport#upgradeSeedTo128bitUnmixed` - Does not apply a stafford 13 mix to the seed
+* `net.minecraft.client.KeyMapping#resetToggleKeys`
+* `net.minecraft.client.gui.components.AbstractScrollWidget#renderBorder`
+* `net.minecraft.client.gui.components.FittingMultiLineTextWidget`
+* `net.minecraft.util.GsonHelper#getNonNull`
+* `net.minecraft.world.level.storage.LevelStorageSource#validateAndCreateAccess`
+* `net.minecraft.world.level.validation.ContentValidationException`
+* `net.minecraft.world.level.validation.DirectoryValidator`
+* `net.minecraft.world.level.validation.PathAllowList`
+
+### Changes and Renames
+
+* `net.minecraft.client.particle.DripParticle#createCherryLeaves*Particle` -> `CherryParticle`
+* An entity's shadow raidus is now rendered at a minimum of 32.
+* `net.minecraft.server.level.ServerEntity#changedPassengers` -> `#removedPassengers`
+* `net.minecraft.world.level.levelgen.structure.templatesystem.ProcessorRule#getOutputTag()` -> `#getOutputTag(RandomSource, CompoundTag)`
+* `net.minecraft.core.Direction#fromNormal` -> `#fromDelta`
+    * All other `#fromNormal` methods and fields have been removed
+* `net.minecraft.world.entity.LivingEntity#*Ridden*` methods now take in a `Player` instead of a `LivingEntity`
+* `net.minecraft.world.entity.animal.camel.Camel#standUpPanic` -> `#standUpInstantly`
+* `net.minecraft.world.entity.Entity#wasKilled` -> `#killedEntity`
+* `net.minecraft.world.level.block.Block#isPossibleToRespawnInThis()` -> `#isPossibleToRespawnInThis(BlockState)
+* `BlockSetType` now accepts a boolean about whether the block can be opened by a hand
+* `net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipPositioner#positionTooltip(Screen, IIIII)` -> `#positionTooltip(IIIIII)`
+* `net.minecraft.commands.CommandSourceStack` now takes in a `IntConsumer` for taking in the return value of a command
+* `net.minecraft.world.inventory.RecipeHolder#awardUsedRecipes(Player)` -> `#awardUsedRecipes(Player, List<ItemStack>)`
+* `net.minecraft.world.level.block.FarmableBlock` is replaced by the block tag `minecraft:maintains_farmland`
+* `net.minecraft.client.Minecraft` or `net.minecraft.server.MinecraftServer` - `#getServiceSignatureValidator` -> `#getProfileKeySignatureValidator`
+* `net.minecraft.data.recipes.RecipeProvider#trimSmithing` now takes in a `ResourceLocation` representing the name of the recipe JSON
+* `net.minecraft.server.level.ServerPlayer#getLevel` -> `#serverLevel`
+* `net.minecraft.server.level.ServerPlayer#setLevel` -> `#setServerLevel`
+* `net.minecraft.util.SpawnUtil$Strategy#LEGACY_IRON_GOLEM` has been deprecated
+* `net.minecraft.world.entity.Entity#level` field -> `#level` method
+   * The `level` field is now private
+   * Settings the field is now done via `#setLevel`
+* `net.minecraft.world.entity.Entity#isOnGround` -> `onGround` method
+   * The `onGround` field is now private
+   * Setting the field is now done via `#setOnGround`
+* `net.minecraft.world.entity.OwnableEntity#getLevel` -> `#level`
+* `net.minecraft.world.entity.ai.behavior.FollowTemptation` can now take in a double representing the 'close enough' radius
+* `net.minecraft.world.level.chunk.ChunkAccess#getHighestSectionPosition` has been deprecated for removal
+* `net.minecraft.client.renderer.LevelRenderer#renderVoxelShape` takes in a additional boolean to change the color of the rendered voxel in debug renderering.
+* `net.minecraft.client.renderer.entity.ItemRenderer` now checks for an animated texture that has foil using `#hasAnimatedTexture`
+    * This method is currently private and hardcoded to the `compasses` item tag or the clock.
+* `net.minecraft.world.entity.LivingEntity#getJumpBoostPower` now returns a `float`
+* `net.minecraft.client.player.LocalPlayer#portalTime` and `#oPortalTime` -> `spinningEffectIntensity` and `#oSpinningEffectIntensity`
+* `net.minecraft.data.recipes.RecipeProvider#coloredWoolFromWhiteWoolAndDye` and `#coloredCarpetFromWhiteCarpetAndDye` have been replaced by `#colorBlockWithDye` which takes in a list of dyes and a list of dyed objects
+* `net.minecraft.server.level.ChunkHolder$FullChunkStatus` -> `level.FullChunkStatus`
+    * The enum values have been changed as well: `BORDER` -> `FULL` and `TICKING` -> `BLOCK_TICKING`
+* `net.minecraft.world.damagesource.DamageSources#outOfWorld` -> `#fellOutOfWorld`
+* `net.minecraft.world.entity.Entity#outOfWorld`, `#checkOutOfWorld` -> `#onBelowWorld`, `#checkBelowWorld`
+* `net.minecraft.server.level.ServerLevel#dragonFight` -> `#getDragonFight`
+* `net.minecraft.world.entity.Entity#getOnPos(F)` is now protected instead of private
+* `net.minecraft.world.inventory.CraftingContainer` -> `TransientCraftingContainer`
+    * `CraftingContainer` is now an interface which `TransientCraftingContainer` extends which specifies the width, height, and list of items within
+* `net.minecraft.world.item.ItemStack#sameItem` -> `#isSameItem`
+* `net.minecraft.commands.CommandSourceStack#sendSuccess(Component, boolean)` -> `#sendSuccess(Supplier<Component>, boolean)`
+* `net.minecraft.world.entity.ai.behavior.FollowTemptation(Function<LivingEntity, Float>, double)` -> `FollowTemptation(Function<LivingEntity, Float>, Function<LivingEntity, Double>)`
+* `net.minecraft.client.gui.components.AbstractSelectionList#clearEntries` is now non-final
+* `net.minecraft.world.damagesource.CombatEntry` is now a record
+* `net.minecraft.world.entity.Entity#positionRider(Entity)` is now final while `#positionRider(Entity, MoveFunction)` is now protected instead of private
+* `net.minecraft.world.level.block.Block#dropResources` - the entity is now nullable
+* `net.minecraft.server.level.ServerPlayer#doCheckFallDamage(double, boolean)` -> `#doCheckFallDamage(double, double, double, boolean)` - now takes in the XZ positions
+* `net.minecraft.world.entity.LivingEntity#sendEffectToRider` -> `#sendEffectToPassengers`
+* `net.minecraft.client.gui.components.AbstractScrollWidget#renderBackground` is now `protected` instead of `private`
+* `net.minecraft.world.item.crafting.ShapedRecipe#itemFromJson` is now `public` instead of `private`
+* `net.miencraft.world.level.storage.WorldLevelData#endDragonFightData` and `#setEndDragonFightData` now operate on `EndDragonFight$Data`
+
+### Removals
+
+* `net.minecraft.world.entity.Entity#teleportPassengers`
+* `net.minecraft.gametest.framework.GameTestHelper#continuouslyUse`
+* `net.minecraft.data.recipes.SmithingTrimRecipeBuilder#save(Consumer, String)`
+* `block` and `new_entity` shaders as they have been unused by Minecraft
+* `net.minecraft.world.item.ItemStack#tagMatches` and `#isSame`
+* `net.minecraft.world.level.block.Block#dropResources(BlockState, LootContext$Builder)`
+* `net.minecraft.world.level.block.Fallable#getHurtsEntitySelector`
+* `net.minecraft.world.level.chunk.ChunkStatus` no longer takes in a string name

--- a/primers/1.20/index.md
+++ b/primers/1.20/index.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Pack Changes
 

--- a/primers/1.21/index.md
+++ b/primers/1.21/index.md
@@ -1,0 +1,721 @@
+# Minecraft 1.20.5/6 -> 1.21 Mod Migration Primer
+
+This is a high level, non-exhaustive overview on how to migrate your mod from 1.20.5/6 to 1.21. This does not look at any specific mod loader, just the changes to the vanilla classes.
+
+This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
+
+If there's any incorrect or missing information, please leave a comment below. Thanks!
+
+## Pack Changes
+
+There are a number of user-facing changes that are part of vanilla which are not discussed below that may be relevant to modders. You can find a list of them on [Misode's version changelog](https://misode.github.io/versions/?id=1.21&tab=changelog).
+
+## Moving Experimental Features
+
+All experimental features which were disabled with the `update_1_21` flag are now moved to their proper locations and implementations. Removed features flags can be seen within `net.minecraft.world.level.storage.WorldData#getRemovedFeatureFlags`.
+
+## ResourceLocation, now Private
+
+The `ResourceLocation` is final and its constructor is private. There are alternatives depending on your usecase:
+
+- `new ResourceLocation(String, String)` -> `fromNamespaceAndPath(String, String)`
+- `new ResourceLocation(String)` -> `parse(String)`
+- `new ResourceLocation("minecraft", String)` -> `withDefaultNamespace(String)`
+- `of` -> `bySeparator`
+- `isValidResourceLocation` is removed
+
+## Depluralizing Registry and Tag Folders
+
+Plural references to the block, entity type, fluid, game event, and item tags have been removed. They should now use their exact registry name. The same goes for registry folders.
+
+- `tags/blocks` -> `tags/block`
+- `tags/entity_types` -> `tags/entity_type`
+- `tags/fluids` -> `tags/fluid`
+- `tags/game_events` -> `tags/game_event`
+- `tags/items` -> `tags/item`
+- `advancements` -> `advancement`
+- `recipes` -> `recipe`
+- `structures` -> `structure`'
+- `loot_tables` -> `loot_table`
+
+## Oh Rendering, why must you change so?
+
+There have been a number of rendering changes. While this will not be an in-depth overview, it will cover most of the surface-level changes.
+
+### Vertex System
+
+The vertex system has received a major overhaul, almost being completely rewritten. However, most of the codebase has some analogue to its previous version in different locations.
+
+First, a `VertexConsumer` is obtained using one of two methods: from a `MultiBufferSource` or the `Tesselator`. Both essentially take a `ByteBufferBuilder`, which handles the direct allocation of the vertex information, and wrap it in a `BufferBuilder`, which writes the data to the `ByteBufferBuilder` while also keeping track of other settings needed to properly write the data, such as the `VertexFormat`.
+
+The `MultiBufferSource` constructs a `VertexConsumer` via `#getBuffer` while `Tesselator` does so via `Tesselator#begin`.
+
+```java
+// For some MultiBufferSource bufferSource
+VertexConsumer buffer = bufferSource.getBuffer(RenderType.translucent());
+
+// Note the different return types when using
+// We will need the BufferBuilder subclass in the future
+BufferBuilder buffer = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
+```
+
+Next, vertices are added to the `VertexConsumer` using the associated methods. `#addVertex` must always be called first, followed by the settings specified in the `VertexFormat`. `#endVertex` no longer exists and is called automatically when calling `#addVertex` or when uploading the buffer.
+
+```java
+// For some VertexConsumer buffer
+buffer.addVertex(0.0f, 0.0f, 2000.0f).setUv(0, 0).setColor(-1);
+buffer.addVertex(0.0f, 1.0f, 2000.0f).setUv(0, 0).setColor(-1);
+buffer.addVertex(1.0f, 1.0f, 2000.0f).setUv(0, 0).setColor(-1);
+buffer.addVertex(1.0f, 0.0f, 2000.0f).setUv(0, 0).setColor(-1);
+```
+
+Once the vertices are added, those using `MultiBufferSource` are done. `MultiBufferSource` will batch the buffers together for each `RenderType` and call the `BufferUploader` within the pipeline. If the `RenderType` sorts the vertices on upload, then it will do so when `endBatch` is called, right before `RenderType#draw` is called to setup the render state and draw the data.
+
+The `Tesselator`, on the other hand, does not handle this logic as you are creating the `BufferBuilder` instance to manage. In this case, after writing all ther vertices, `BufferUploader#drawWithShader` should be called. The `MeshData` provided, which contains the vertex and index buffer along with the draw state, can be built via `BufferBuilder#buildOrThrow`. This replaces `BufferBuilder#end`.
+
+```java
+// For some BufferBuilder buffer
+BufferUploader.drawWithShader(buffer.buildOrThrow());
+```
+
+#### Changes
+
+- `com.mojang.blaze3d.vertex.DefaultVertexFormat`'s `VertexFormatElement`s have been moved to `VertexFormatElement`.
+- `com.mojang.blaze3d.vertex.BufferBuilder$RenderedBuffer` -> `MeshData`
+- `com.mojang.blaze3d.vertex.VertexConsumer`
+    - `vertex` -> `addVertex`
+        - Overload with `PoseStack$Pose, Vector3f`
+    - `color` -> `setColor`
+    - `uv` -> `setUv`
+    - `overlayCoords` -> `setUv1`, `setOverlay`
+    - `uv2` -> `setUv2`, `setLight`
+    - `normal` -> `setNormal`
+    - `endVertex` is removed
+    - `defaultColor`, `color` -> `setColor`, `setWhiteAlpha`
+- `net.minecraft.client.model.Model#renderToBuffer` now takes in an integer representing the ARGB tint instead of four floats
+    - There is also a final method which passes in no tint
+- `net.minecraft.client.model.geom.ModelPart#render`, `$Cube#compile` now takes in an integer representing the ARGB tint instead of four floats
+    - There is also an overloaded method which passes in no tint
+- `net.minecraft.client.particle.ParticleRenderType#begin(Tesselator, TextureManager)`, `end` -> `begin(BufferBuilder, TextureManager)`
+    - This method returns the `BufferBuilder` rather than void
+    - When `null`, no rendering will occur
+- Shader removals and replacements
+    - `minecraft:position_color_tex` -> `minecraft:position_tex_color`
+    - `minecraft:rendertype_armor_glint` -> `minecraft:rendertype_armor_entity_glint`
+    - `minecraft:rendertype_glint_direct` -> `minecraft:rendertype_glint`
+- `net.minecraft.client.renderer.MultiBufferSource`
+    - All `BufferBuilder`s have been replaced with `ByteBufferBuilder`
+    - `immediateWithBuffers` now takes in a `SequencedMap`
+- `net.minecraft.client.renderer.RenderType`
+    - `end` -> `draw`
+    - `sortOnUpload` - When true, sorts the quads according to the `VertexSorting` method for the `RenderType`
+- `net.minecraft.client.renderer.SectionBufferBuilderPack#builder` -> `#buffer`
+- `net.minecraft.client.renderer.ShaderInstance` no longer can change the blend mode, only `EffectInstance` can, which is applied for `PostPass`
+    - `setDefaultUniforms` - Sets the default uniforms accessible to all shader instances
+- `net.minecraft.client.renderer.entity.ItemRenderer`
+    - `getArmorFoilBuffer` no longer takes in a boolean to change the render type
+    - `getCompassFoilBufferDirect` is removed
+- `net.minecraft.client.renderer.entity.layers.RenderLayer#coloredCutoutModelCopyLayerRender`, `renderColoredCutoutModel` takes in an integer representing the color rather than three floats
+- `com.mojang.blaze3d.vertex.BufferVertexConsumer` is removed
+- `com.mojang.blaze3d.vertex.DefaultedVertexConsumer` is removed
+
+### Chunk Regions
+
+- `net.minecraft.client.renderer.chunk.RenderRegionCache#createRegion` only takes in the `SectionPos` now instead of computing the section from the `BlockPos`
+- `net.minecraft.client.renderer.chunk.SectionCompiler` - Renders the given chunk region via `#compile`. Returns the results of the rendering compilation.
+    - This is used within `SectionRenderDispatcher` now to pass around the stored results and upload them
+
+## The Enchantment Datapack Object
+
+`Enchantment`s are now a datapack registry object. Querying them requires access to a `HolderLookup.Provider` or one of its subclasses.
+
+All references to `Enchantment`s are now wrapped with `Holder`s. Some helpers can be found within `EnchantmentHelper`.
+
+```json5
+{
+    // A component containing the description of the enchantment
+    // Typically will be a component with translatable contents
+    "description": {
+        "translate": "enchantment.minecraft.example"
+    },
+    // An item tag that holds all items this enchantment can be applied to
+    "supported_items": "#minecraft:enchantable/weapon",
+    // An item tag that holds a subset of supported_items that this enchantment can be applied to in an enchanting table
+    "primary_items": "#minecraft:enchantable/sharp_weapon",
+    // A non-negative integer that provides a weight to be added to a pool when trying to get a random enchantment
+    "weight": 3,
+    // A non-negative integer that indicates the maximum level of the enchantment
+    "max_level": 4,
+    // The minimum cost necessary to apply this enchantment to an item
+    "min_cost": {
+        // The base cost of the enchantment at level 1
+        "base": 10,
+        // The amount to increase the cost with each added level
+        "per_level_above_first": 20
+    },
+    // The maxmimum cost required to apply this enchantment to an item
+    "max_cost": {
+        "base": 60,
+        "per_level_above_first": 20
+    }
+    // A non-negative integer that determines the cost to add this enchantment via the anvil
+    "anvil_cost": 5,
+    // The equipment slot groups this enchantment is applied to
+    // Can be 'any', 'hand' ('mainhand' and 'offhand'), 'armor' ('head', 'chest', 'legs', and 'feet'), or 'body'
+    "slots": [
+        "hand"
+    ],
+    // An enchantment tag that contains tags that this enchantment cannot be on the same item with
+    "exclusive_set": "#minecraft:exclusive_set/damage",
+    // An encoded data component map which contains the effects to apply
+    "effects": {
+        // Read below
+    },
+}
+```
+
+### EnchantmentEffectComponents
+
+`EnchantmentEffectComponents` essentially apply how enchantments should react in a given context when on an item. Each effect component is encoded as an object with its component id as the key and the object value within the effect list, usually wrapped as a list. Most of these components are wrapped in a `ConditionalEffect`, so that will be the focus of this primer.
+
+#### ConditionalEFfect
+
+`ConditionalEffect`s are basically a pair of the effect to apply and a list of loot conditions to determine when to execute the enchantment. The codec provided contains the effect object code and the loot context param sets to apply for the conditions (commonly one of the `ENCHANTED_*` sets).
+
+#### The Effect Objects
+
+Each effect object has its own combination of codecable objects and abstract logic which may refer to other registered types, similiar to loot conditions, functions, number providers, etc. For enchantments currently, this means enchantments which are applied directly to the entity, scaled and calulated for some numerical distribution, applied to the blocks around the entity, or calculating a number for some information.
+
+For example, all protection enchantments use almost the exact same effect objects (`minecraft:attributes` and `minecraft:damage_protection`) but use the conditions to differentiate when those values should be applied.
+
+To apply these enchantments, `EnchantmentHelper` has a bunch of different methods to help with the application. Typically, most of these are funneled through one of the `runIterationOn*` methods. These method take in the current context (e.g., stack, slot, entity) and a visitor which holds the current enchantment, level, and optionally the stack context if the item is in use. The visitor takes in a mutable object which holds the final value to return. The modifications to apply to the given item(s) are within `Enchantment#modify*`. If the conditions match, then the value from the mutable object is passed in, processed, and set back to the object.
+
+### Enchantment Providers
+
+`EnchantmentProvider`s are a provider of enchantments to items for entity inventory items or for custom loot on death. Each provider is some number of enchantments that is then randomly selected from and applied to the specified stacks via `EnchantmentHelper#enchantItemFromProvider` which takes in the stack to enchant, the registry access, the provider key, the difficulty instance, and the random instance.
+
+### Minor Changes
+
+- `net.minecraft.world.entity.LivingEntity#activeLocationDependentEnchantments` - Returns the enchantments which depend on the current location of the entity
+- `net.minecraft.world.entity.Entity#doEnchantDamageEffects` has been removed
+- `net.minecraft.world.entity.npc.VillagerTrades$ItemListing` implementations with `Enchantment`s now take in keys or tags of the corresponding object
+- `net.minecraft.world.entity.player.Player#getEnchantedDamage` - Gets the dmaage of a source modified by the current enchantments
+- `net.minecraft.world.entity.projectile.AbstractArrow#hitBlockEnchantmentEffects` - Applies the enchantment modifiers when a block is hit
+- `net.minecraft.world.entity.projectile.AbstractArrow#setEnchantmentEffectsFromEntity` has been removed
+- `net.minecraft.world.item.ItemStack#enchant` takes in a `Holder<Enchantment>` instead of the direct object
+- `net.minecraft.world.entity.Mob#populateDefaultEquipmentEnchantments`, `enchantSpawnedWeapon`, `enchantSpawnedArmor` now take in a `ServerLevelAccessor` and `DifficultyInstance`
+
+## The Painting Variant Datapack Object
+
+`PaintingVariant`s are now a datapack registry object. Querying them requires access to a `HolderLookup.Provider` or one of its subclasses.
+
+```json5
+{
+    // A relative location pointing to 'assets/<namespace>/textures/painting/<path>.png
+    "asset_id": "minecraft:courbet",
+    // A value between 1-16 representing the number of blocks this variant takes up
+    // e.g. a width of 2 means it takes up 2 blocks, and has an image size of 32px
+    "width": 2,
+    // A value between 1-16 representing the number of blocks this variant takes up
+    // e.g. a height of 1 means it takes up 1 blocks, and has an image size of 16px
+    "height": 1
+}
+```
+
+## Attribute Modifiers, now with ResourceLocations
+
+`AttributeModifier`s no longer take in a `String` representing its UUID. Instead, a `ResourceLocation` is provided to uniquely identity the modifier to apply. Attribute modifiers can be compared for `ResourceLocation`s using `#is`.
+
+- `net.minecraft.world.effect.MobEffect`
+    - `addAttributeModifier`, `$AttributeTemplate` takes in a `ResourceLocation` instead of a `String`
+- `net.minecraft.world.entity.ai.attributes.AttributeInstance`
+    - `getModifiers` returns a `Map<ResourceLocation, AttributeModifier>`
+    - `getModifier`, `hasModifier`, `removeModifier` now takes in a `ResourceLocation`
+    - `removeModifier` now returns a boolean
+    - `removePermanentModifier` is removed
+    - `addOrReplacePermanentModifier` - Adds or replaces the provided modifier
+- `net.minecraft.world.entity.ai.attributes.AttributeMap`
+    - `getModifierValue`, `hasModifier`, now takes in a `ResourceLocation`
+- `net.minecraft.world.entity.ai.attributes.AttributeSupplier`
+    - `getModifierValue`, `hasModifier`, now takes in a `ResourceLocation`
+
+## RecipeInput
+
+`Recipe`s now take in a `net.minecraft.world.item.crafting.RecipeInput` instead of a `Container`. A `RecipeInput` is basically a minimal view into a list of available stacks. It contains three methods:
+
+- `getItem` - Returns the stack in the specified index
+- `size` - The size of the backing list
+- `isEmpty` - true if all stacks in the list are empty
+
+As such, all implementations which previous took a `Container` now take in a `RecipeInput`. You can think of it as replacing all the `C` generics with a `T` generic representing the `RecipeInput`. This also includes `RecipeHolder`, `RecipeManager`, and the others below.
+
+### CraftingInput
+
+`CraftingInput` is an implementation of `RecipeInput` which takes in width and height of the grid along with a list of `ItemStack`s. One can be created using `CraftingInput#of`. These are used in crafting recipes.
+
+### SingleRecipeInput
+
+`SingleRecipeInput` is an implementation of `RecipeInput` that only has one item. One can be created using the constructor.
+
+## Changing Dimensions
+
+How entities change dimensions have been slightly reworked in the logic provided. Instead of providing a `PortalInfo` to be constructed, instead everything returns a `DimensionTransition`. `DimensionTransition` contains the level to change to, the entity's position, speed, and rotation, and whether a respawn block should be checked. `DimensionTransition` replaces `PortalInfo` in all scenarios.
+
+Entities have two methods for determining whether they can teleport. `Entity#canUsePortal` returns true if the entity can use a `Portal` to change dimensions, where the boolean supplies allows entities who are passengers to teleport. To actually change dimensions, `Entity#canChangeDimensions` must return true, where the current and teleporting to level is provided. Normally, only `canUsePortal` is changed while `canChangeDimensions` is always true.
+
+> `canChangeDimensions` functioned as `canUsePortal` in 1.20.5/6. 
+
+To change dimensions via a portal, a `Portal` should be supplied to `Entity#setAsInsidePortal`. A `Portal` contains how long it takes for the portal to transition, the `DimensionTransition` destination, and the transition effect to apply to the user. This is all wrapped in a `PortalProcessor` and stored on the `Entity`. Once the player is teleported a `DimensionTransition$PostDimensionTransition` is executed, for example playing a sound.
+
+`Portal`s are generally implmented on the `Block` doing the teleporting.
+
+- `net.minecraft.world.entity.Entity`
+    - `changeDimension(ServerLevel)` -> `changeDimension(DimensionTransition)`
+    - `findDimensionEntryPoint` -> `Portal#getPortalDestination`
+    - `getPortalWaitTime` -> `Portal#getPortalTransitionTime`
+    - `handleInsidePortal` -> `setAsInsidePortal`
+    - `handleNetherPortal` -> `handlePortal`
+    - `teleportToWithTicket` is removed
+    - `getRelativePortalPosition` is now public
+- `net.minecraft.world.level.portal.PortalShape`
+    - `createPortalInfo` is removed
+    - `findCollisionFreePosition` is now public
+- `net.minecraft.client.player.LocalPlayer#getActivePortalLocalTransition` - Defines the transition to apply to the entity when the player is within a portal
+- `net.minecraft.world.level.portal.PortalForce#findPortalAround` -> `findClosestPortalPosition`
+
+### Minor Changes
+
+- `net.minecraft.recipebook.ServerPlaceRecipe` now has a generic taking in the `RecipeInput` and the `Recipe` rather than the `Container`
+- `net.minecraft.world.inventory.CraftingContainer#asCraftInput` - Converts a crafting container to an input to supply
+- `net.minecraft.world.inventory.CraftingContainer#asPositionedCraftInput` - Converts a crafting container to an input positioned at some location within a grid
+- `net.minecraft.world.inventory.CraftingMenu#slotChangedCraftingGrid` now takes in a `RecipeHolder`
+- `net.minecraft.world.inventory.RecipeBookMenu` now has a generic taking in the `RecipeInput` and the `Recipe` rather than the `Container`
+  - `beginPlacingRecipe` - When the recipe is about to be placed in the corresponding location
+  - `finishPlacingRecipe` - AFter the recipe has been placed in the corresponding location
+- `net.minecraft.client.gui.screens.recipebook.*RecipeComponent#addItemToSlot` still exists but is no longer overridded from its subclass
+
+## Minor Migrations
+
+The following is a list of useful or interesting additions, changes, and removals that do not deserve their own section in the primer.
+
+### Options Screens Movement
+
+The options screens within `net.minecraft.client.gui.screens` and `net.minecraft.client.gui.screens.controls` have been moved to `net.minecraft.client.gui.screens.options` and `net.minecraft.client.gui.screens.options.controls`, respectively.
+
+### The HolderLookup$Provider in LootTableProvider
+
+`net.minecraft.data.loot.LootTableProvider$SubProviderEntry` takes in a function which provides the `HolderLookup$Provider` and returns the `LootTableSubProvider`. `LootTableSubProvider#generate` no longer takes in a `HolderLookup$Provider` as its first argument.
+
+### DecoratedPotPattern Object
+
+`Registries#DECORATED_POT_PATTERNS` takes in a `DecoratedPotPattern` instead of the raw string for the asset id. This change has been reflected in all subsequent classes (e.g. `Sheets`).
+
+### Jukebox Playable
+
+`RecordItem`s has been removed in favor of a new data component `JukeboxPlayable`. This is added via the item properties. A jukebox song is played via `JukeboxSongPlayer`. `JukeboxBlockEntity` handles an implementation of `JukeboxSongPlayer`, replacing all of the logic handling within the class itself.
+
+- `net.minecraft.world.item.Item$Properties#jukeboxPlayable` - Sets the song to play in a jukebox when this is added
+- `net.minecraft.world.item.JukeboxSong` - A `SoundEvent`, description, length, and comparator output record indicating what this item would do when placed in a jukebox
+    - This is a datapack registry
+- `net.minecraft.world.item.JukeboxPlayable` - The data component for a `JukeboxSong`
+- `net.minecraft.world.item.JukeboxSongPlayer` - A player which handles the logic of how a jukebox song is played
+- `net.minecraft.world.level.block.entity.JukeboxBlockEntity#getComparatorOutput` - Gets the comparator output of the song playing in the jukebox
+
+### Chunk Generation Reorganization
+
+Chunk generation has been reorganized again, where generation logic is moved into separate maps, task, and holder classes to be executed and handled asyncronously in most instances. Missing methods can be found in `ChunkGenerationTask`, `GeneratingChunkMap`, or `GenerationChunkHolder`. Additional chunk generation handling is within `net.minecraft.world.level.chunk.status.*`.
+
+This also means some region methods which only contain generation-based information have been replaced with one of these three classes instead of their constructed counterparts. The steps are now listed in a `ChunkPyramid`, which determines the steps takes on how a protochunk is transformed into a full chunk. Each step can have a `ChunkDependencies`, forcing the order of which they execute. `ChunkPyramid#GENERATION_PYRAMID` handles chunk generation during worldgen while `LOADING_PYRAMID` handles loading a chunk that has already been generated. The `WorldGenContext` holds a reference to the main thread box when necessary.
+
+### Delta Tracker
+
+`net.minecraft.client.DeltaTracker` is an interface mean to keep track of the delta ticks, both ingame and real time. This also holds the current partial tick. This replaces most instances passing around the delta time or current partial tick.
+
+- `net.minecraft.client.Minecraft#getFrameTime`, `getDeltaFrameTime` -> `getTimer`
+- `net.minecraft.client.Timer` -> `DeltaTracker$Timer`
+- `net.minecraft.client.gui.Gui#render` now takes in a `DeltaTracker`
+
+### Additions
+
+- `com.mojang.realmsclient.dto.RealmsServer#isMinigameActive` - Returns whether a minigame is active.
+- `net.minecraft.SystemReport#sizeInMiB` - Converts a long representing the number of bytes into a float representing Mebibyte (Power 2 Megabyte)
+- `net.minecraft.Util#isSymmetrical` - Checks whether a list, or some subset, is symmetrical
+- `net.minecraft.advancements.critereon.MovementPredicate` - A predicate which indicates how the entity is currently moving
+- `net.minecraft.client.gui.components.AbstractSelectionList#clampScrollAmount` - Clamps the current scroll amount
+- `net.minecraft.client.gui.screens.AccessibilityOnboardingScreen#updateNarratorButton` - Updates the narrator button
+- `net.minecraft.client.gui.screens.worldselection.WorldCreationContext#validate` - Validates the generators of all datapack dimensions
+- `net.minecraft.client.multiplayer.ClientPacketListener`
+  - `updateSearchTrees` - Rebuilds the search trees for creative tabs and recipe collections
+  - `searchTrees` - Gets the current search trees for creative tabs and recipe collections
+- `net.minecraft.client.multiplayer.SessionSearchTrees` - The data contained for creative tabs and recipe collections on the client
+- `net.minecraft.commands.arguments.item.ItemParser$Visitor#visitRemovedComponent` - Executed when a component is to be removed as part of an item input
+- `net.minecraft.core.Registry#getAny` - Gets an element from the registry, usually the first one registered
+- `net.minecraft.core.component.DataComponentMap`
+  - `makeCodec` - Creates a component map codec from a component type codec
+  - `makeCodecFromMap` - Creates a component map codec from a component type to object map codec
+- `net.minecraft.util.ProblemReporter#getReport` - Returns a report of the problem
+- `net.minecraft.util.Unit#CODEC`
+- `net.minecraft.world.damagesource.DamageSources#campfire` - Returns a source where the damage was from a campfire
+- `net.minecraft.world.damagesource.DamageType#CODEC`
+- `net.minecraft.world.entity.LivingEntity`
+  - `hasLandedInLiquid` - Returns whether the entity is moving faster than -0.00001 in the y direction while in a liquid
+  - `getKnockback` - Gets the knockback to apply to the entity
+- `net.minecraft.world.entity.Mob#playAttackSound` - Executes when the mob should play a sound when attacking
+- `net.minecraft.world.entity.ai.attributes.Attribute#CODEC`
+- `net.minecraft.world.entity.ai.attributes.AttibuteMap`
+  - `addTransientAttributeModifiers` - Adds all modifiers from the provided map
+  - `removeAttributeModifiers` - Removes all modifiers in the provided map
+- `net.minecraft.world.entity.projectile.AbstractArrow`
+  - `getWeaponItem` - The weapon the arrow was fired from
+  - `setBaseDamageFromMob` - Sets the base damage this arrow can apply
+- `net.minecraft.world.entity.projectile.Projectile#calculateHorizontalHurtKnockbackDirection` - Returns the horizontal vector of the knockback direction
+- `net.minecraft.world.inventory.ArmorSlot` - A slot for armor
+- `net.minecraft.world.item.CrossbowItem#getChargingSounds` - Sets the sounds to play when pulling back the crossbow
+- `net.minecraft.world.item.Item#postHurtEntity` - Gets called after the enemy has been hurt by this item
+- `net.minecraft.world.level.Explosion#canTriggerBlocks` - Returns whether the explosion cna trigger a block
+- `net.minecraft.world.level.block.LeverBlock#playSound` - Plays the lever click sound
+- `net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate`
+  - `unobstructed` - Returns a predicate which indicates the current vector is not obstructed by another entity
+- `net.minecraft.world.level.storage.loot.functions.EnchantedCountIncreaseFunction` - A function which grows the loot based on the corresponding enchantment level
+- `net.minecraft.world.level.storage.loot.predicates.EnchantmentActiveCheck` - Checks whether a given enchantment is applied
+- `net.minecraft.world.level.storage.loot.providers.number.EnchantmentLevelProvider` - Determines the enchantment level to provide
+- `net.minecraft.world.phys.AABB#move` - An overload of `#move` which takes in a `Vector3f`
+- `net.minecraft.core.dispenser.DefaultDispenseItemBehavior#consumeWithRemainder` - Shrinks the first item stack. If empty, then the second item stack is returned. Otherwise, the second item stack is added to an inventory or dispensed, and the first item stack is returned.
+- `net.minecraft.server.MinecraftServer`
+    - `throwIfFatalException` - Throws an exception if its variable isn't null
+    - `setFatalException` - Sets the fatal exception to throw
+- `net.minecraft.util.StaticCache2D` - A two-dimensional read-only array which constructs all objects on initialization
+- `net.minecraft.world.entity.Entity`
+    - `fudgePositionAfterSizeChange` - Returns whether the entity's position can be moved to an appropriate free position after its dimension's change
+    - `getKnownMovement` - Returns the current movement of the entity, or the last known client movement of the player
+- `net.minecraft.world.entity.ai.attributes.Attribute`
+    - `setSentiment` - Sets whether the attribute provides a positive, neutral or negative benefit when the value is positive
+    - `getStyle` - Gets the chat formatting of the text based on the sentiment and whether the attribite value is positive
+- `net.minecraft.world.entity.ai.attributes.AttributeMap#getAttributestoSync` - Returns the attributes to sync to the client
+- `net.minecraft.world.level.storage.loot.LootContext$Builder#withOptionalRandomSource` - Sets the random source to use for the loot context during generation
+    - This is passed by `LootTable#getRandomItems(LootParams, RandomSource)`
+- `net.minecraft.client.Options#genericValueOrOffLabel` - Gets the generic value label, or an on/off component if the integer provided is 0
+- `net.minecraft.client.gui.GuiGraphics#drawStringWithBackdrop` - Draws a string with a rectangle behind it
+- `net.minecraft.gametest.framework.GameTestHelper`
+    - `assertBlockEntityData` - Asserts that the block entity has the given information
+    - `assertEntityPosition` - Asserts that the enity position is within a bounding box
+- `net.minecraft.server.level.ServerPlayer#copyRespawnPosition` - Copies the respawn position from another player
+- `net.minecraft.server.players.PlayerList#sendActiveEffects`, `sendActivePlayerEffects` - Sends the current entity's effects to the client using the provided packet listener
+- `net.minecraft.util.Mth#hsvToArgb` - Converts an HSV value with an alpha integer to ARGB
+- `net.minecraft.world.entity.Entity#absRotateTo` - Rotates the y and x of the entity clamped between its maximum values
+- `net.minecraft.world.entity.ai.attributes.AttributeMap#assignBaseValues` - Sets the base value for each attribute in the map
+- `net.minecraft.world.item.ItemStack#forEachModifier` - An overload which applies the modifier for each equipment slot in the group
+    - Applies to `net.minecraft.world.item.component.ItemAttributeModifiers#forEach` as well
+- `net.minecraft.world.level.levelgen.PositionalRandomFactory#fromSeed` - Constructs a random instance from a seed
+- `net.minecraft.world.level.levelgen.structure.pools.DimensionPadding` - The padding to apply above and below a structure when attempting to generate
+- `net.minecraft.ReportType` - An object that represents a header plus a list of nuggets to display after the header text
+- `net.minecraft.advancements.critereon.GameTypePredicate` - A predicate that checks the game type of the player (e.g. creative, survival, etc.)
+- `net.minecraft.advancements.critereon.ItemJukeboxPlayablePredicate` - A predicate that checks if the jukebox is playing a song
+- `net.minecraft.core.BlockPos#clampLocationWithin` - Clamps the vector within the block
+- `net.minecraft.core.registries.Registries`
+    - `elementsDirPath` - Gets the path of the registry key
+    - `tagsDirPath` - Gets the tags path of the registry key (replaces `TagManager#getTagDir`
+- `net.minecraft.network.DisconnectionDetails` - Information as to why the user was disconnected from the current world
+- `net.minecraft.server.MinecraftServer#serverLinks` - A list of entries indicating what the link coming from the server is
+    - Only used for bug reports
+- `net.minecraft.util.FastColor`
+    - `$ABGR32#fromArgb32` - Reformats an ARGB32 color into a ABGR32 color
+    - `$ARGB32#average` - Averages two colors together by each component
+- `net.minecraft.util.Mth#lengthSquared` - Returns the squared distance of three floats
+- `net.minecraft.world.entity.LivingEntity#triggerOnDeathMobEffects` - Trigers the mob effects when an entity is killed
+- `net.minecraft.world.entity.TamableAnimal`
+    - `tryToTeleportToOwner` - Attempts to teleport to the entity owner
+    - `shouldTryTeleportToOwner` - Returns true if the entity owner is more than 12 blocks away
+    - `unableToMoveToOwner` - Returns true if the animal cannot move to the entity owner
+    - `canFlyToOwner` - Returns true if the animal can fly to the owner
+- `net.minecraft.world.entity.projectile.Projectile#disown` - Removes the owner of the projectile
+- `net.minecraft.world.item.EitherHolder` - A holder which either contains the holder instance or a resource key
+- `net.minecraft.world.level.chunk.ChunkAccess#isSectionEmpty` - Returns whether the section only has air
+- `net.minecraft.FileUtil#sanitizeName` - Replaces all illegal file charcters with underscores
+- `net.minecraft.Util#parseAndValidateUntrustedUri` - Returns a URI after validating that the protocol scheme is supported
+- `net.minecraft.client.gui.screens.ConfirmLinkScreen` now has two overloads to take in a `URI`
+    - `confirmLinkNow` and `confirmLink` also has overloads for a `URI` parameter
+- `net.minecraft.client.renderer.LevelRenderer#renderFace` - Renders a quad given two points and a color
+- `net.minecraft.client.renderer.entity.EntityRenderer#renderLeash` - A **private** method that renders the leash for an entity
+- `net.minecraft.client.resources.model.BlockStateModelLoader` - Loads the blockstate definitions for every block in the registry
+    - Anything missing from `ModelBakery` is most likely here
+- `net.minecraft.client.resources.model.ModelBakery$TextureGetter` - Gets the `TextureAtlasSprite` given the model location and the material provided
+- `net.minecraft.core.BlockPos#getBottomCenter` - Gets the `Vec3` representing the bottom center of the position
+- `net.minecraft.gametest.framework.GameTestBatchFactory#fromGameTestInfo(int)` - Batches the game tests into the specified partitions
+- `net.minecraft.gametest.framework.GameTestHelper#getTestRotation` - Gets the rotation of the structure from the test info
+- `net.minecraft.gametest.framework.GameTestRunner$StructureSpawner#onBatchStart` - Executes when the batch is going to start running within the level
+- `net.minecraft.network.ProtocolInfo$Unbound`
+    - `id` - The id of the protocol
+    - `flow` - The direction the packet should be sent
+    - `listPackets` - Provides a visitor to all packets that can be sent on this protocol
+- `net.minecraft.network.chat.Component#translationArg` - Creates a component for a `URI`
+- `net.minecraft.network.protocol.game.VecDeltaCodec#getBase` - Returns the base vector before encoding
+- `net.minecraft.server.level.ServerEntity`
+    - `getPositionBase` - Returns the current position of the entity
+    - `getLastSentMovement` - Gets the vector representing the last velocity of the entity sent to the client
+    - `getLastSentXRot` - Gets the last x rotation of the entity sent to the client
+    - `getLastSentYRot` - Gets the last y rotation of the entity sent to the client
+    - `getLastSentYHeadRot` - Gets the last y head rotation of the entity sent to the client
+- `net.minecraft.world.damagesource.DamageSource#getWeaponItem` - Returns the itemstack the direct entity had
+- `net.minecraft.world.entity.Entity`
+    - `adjustSpawnLocation` - Returns the block pos representing the spawn location of the entity. By default, returns the entity spawn location
+    - `moveTo` has an overload taking in a `Vec3`
+    - `placePortalTicket` - Adds a region ticket that there is a portal at the `BlockPos`
+    - `getPreciseBodyRotation` - Lerps between the previous and current body rotation of the entity
+    - `getWeaponItem` - The item the entity is holding as a weapon
+- `net.minecraft.world.entity.Leashable` - Indicates that an entity can be leashed
+- `net.minecraft.world.entity.Mob`
+    - `dropPreservedEquipment` - Drops the equipment the entity is wearing if it doesn't match the provided predicate or if the equipment succeeds on the drop chance check
+- `net.minecraft.world.entity.player.Player`
+    - `setIgnoreFallDamageFromCurrentImpulse` - Ignores the fall damage from the current impulses for 40 ticks when true
+    - `tryResetCurrentImpulseContext` - Resets the impulse if the grace time reaches 0
+- `net.minecraft.world.item.ItemStack#hurtAndConvertOnBreak` - Hurts the stack and when the item breaks, sets the item to another item
+- `net.minecraft.world.level.chunk.storage.ChunkIOErrorReporter` - Handles error reporting for chunk IO failures
+- `net.minecraft.world.level.chunk.sotrage.ChunkStorage`, `IOWorker`, `RegionFileStorage`, `SimpleRegionStorage#storageInfo` - Returns the `RegionStorageInfo` used to store the chunk
+- `net.minecraft.world.level.levelgen.structure.Structure$StructureSettings` now has a constructor with default values given the biome tag
+    - `$Builder` - Builds the settings for the structure
+- `net.minecraft.world.level.levelgen.structure.templatesystem.LiquidSettings` - The settings to apply for blocks spawning with liquids within them
+- `net.minecraft.world.level.storage.loot.ValidationContext` now has an constructor overload taking in an empty `HolderGetter$Provider`
+    - `allowsReferences` - Checks whether the resolver is present
+- `net.minecraft.client.Options#onboardingAccessibilityFinished` - Disables the onboarding accessibility feature
+- `net.minecraft.client.gui.screens.reporting.AbstractReportScreen`
+    - `createHeader` - Creates the report header
+    - `addContent` - Adds the report content
+    - `createFooter` - Creates the report footer
+    - `onReportChanged` - Updates the report information, or sets a `CannotBuildReason` if not possible to change
+- `net.minecraft.client.multiplayer.chat.report.Report#attested` - Sets whether the user has read the report and wants to send it
+- `net.minecraft.world.level.levelgen.feature.EndPlatformFeature` - A feature that generates the end platform
+- `net.minecraft.world.level.levelgen.placement.FixedPlacement` - A placement that places a feature in one of the provided positions
+- `net.minecraft.world.phys.AABB`
+    - `getBottomCenter` - Gets the `Vec3` representing the bottom center of the box
+    - `getMinPosition` - Gets the `Vec3` representing the smallest coordinate of the box
+    - `getMaxPosition` - Gets the `Vec3` representing the largest coordinate of the box
+- `net.minecraft.world.entity.player.Player#isIgnoringFallDamageFromCurrentImpulse` - Returns whether the player should ignore fall damage
+- `net.minecraft.world.item.LeadItem#leashableInArea` - Returns a list of Leashable entities within a 7 block radius of the provided block position
+
+### Changes
+
+- `net.minecraft.advancements.critereon.EnchantmentPredicate` now takes in a `HolderSet<Enchantment`
+  - The previous constructor still exists as an overload
+- `net.minecraft.advancements.critereon.EntityFlagsPredicate` now takes in a boolean for if the entity is on the ground or flying
+- `net.minecraft.advancements.critereon.EntityPredicate` now takes in a movement predicate and periodic tick which indicates when the predicate can return true
+- `net.minecraft.advancements.critereon.LocationPredicate` now takes in a fluid predicate
+- `net.minecraft.client.gui.components.AbstractSelectionList#setScrollAmount` -> `setClampedScrollAmount`
+  - `setScrollAmount` now delegates to this method
+- `net.minecraft.client.gui.components.OptionsList` now longer takes in the unused integer
+- `net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen` now takes in a `LocalPlayer` instead of a `Player`
+- `net.minecraft.client.resources.language.LanguageManager` now takes in a `Consumer<ClientLanguage>` which acts as a callback when resources are reloaded
+- `net.minecraft.client.searchtree.PlainTextSearchTree` -> `SearchTree#plainText`
+- `net.minecraft.client.searchtree.RefreshableSearchTree` -> `SearchTree`
+- `net.minecraft.commands.arguments.item.ItemInput` now takes in a `DataComponentPatch` instead of a `DataComponentMap`
+- `net.minecraft.core.component.TypedDataComponent#createUnchecked` is now public
+- `net.minecraft.data.loot.BlockLootSubProvider` now takes in a `HolderLookup$Provider`
+  - `HAS_SILK_TOUCH` -> `hasSilkTouch` 
+  - `HAS_NO_SILK_TOUCH` -> `doesNotHaveSilkTouch`
+  - `HAS_SHEARS_OR_SILK_TOUCH` -> `hasShearsOrSilkTouch`
+  - `HAS_NO_SHEARS_OR_SILK_TOUCH` -> `doesNotHaveShearsOrSilkTouch`
+  - Most protected static methods were turned into instance methods
+- `net.minecraft.data.loot.EntityLootSubProvider` now takes in a `HolderLookup$Provider`
+- `net.minecraft.data.recipes.RecipeProvider#trapdoorBuilder` is now protected
+- `net.minecraft.recipebook.ServerPlaceRecipe`
+  - `addItemToSlot` now takes in an `Integer` instead of a `Iterator<Integer>`
+  - `moveItemToGrid` now takes in an integer representing the minimum count and returns the number of items remaining that can be moved with the minimum count in place
+- `net.minecraft.resources.RegistryDataLoader`
+  - `load` is now private
+  - `$RegistryData` now takes in a boolean indicating whether the data must have an element
+- `net.minecraft.world.damagesource.CombatRules#getDamageAfterAbsorb` now takes in a `LivingEntity`
+- `net.minecraft.world.entity.Entity#igniteForSeconds` now takes in a float
+- `net.minecraft.world.entity.LivingEntity`
+  - `onChangedBlock` now takes in a `ServerLevel`
+  - `getExperienceReward` -> `getBaseExperienceReward`
+    - `getExperienceReward` is now final and takes in the `ServerLevel` and `Entity`
+  - `getRandom` -> `Entity#getRandom` (usage has not changed)
+  - `dropExperience` now takes in a nullable `Entity`
+  - `dropCustomDeathLoot` no longer takes in an integer
+  - `jumpFromGround` is now public for testing
+- `net.minecraft.world.entity.monster.AbstractSkeleton#getArrow` now keeps track of the weapon it was fired from
+- `net.minecraft.world.entity.player.Player$startAutoSpinAttack` now takes in a float representing the damage and a stack representing the item being held
+- `net.minecraft.world.entity.projectile.AbstractArrow` now keeps track of the weapon it was fired from
+  - `setPierceLevel` is now private
+- `net.minecraft.world.entity.projectile.ProjectileUtil#getMobArrow` now keeps track of the weapon it was fired from
+- `net.minecraft.world.item.CrossbowItem#getChargeDuration` now takes in an `ItemStack` and `LivingEntity`
+- `net.minecraft.world.item.Item`
+  - `getAttackDamageBonus` now takes in an `Entity` and `DamageSource` instead of just the `Player`
+  - `getUseDuration` now takes in a `LivingEntity`
+- `net.minecraft.world.item.ItemStack`
+  - `hurtAndBreak` now takes in a `ServerLevel` instead of a `RandomSource`
+  - `hurtEnemy` now returns a boolean if the entity was succesfully hurt
+- `net.minecraft.world.item.MaceItem#canSmashAttack` takes in a `LivingEntity` instead of a `Player`
+- `net.minecraft.world.item.ProjectileWeaponItem#shoot` takes in a `ServerLevel` instead of a `Level`
+- `net.minecraft.world.item.component.CustomData`
+  - `update` now takes in a `DynamicOps<Tag>`
+  - `read` now has an overload that takes in a `DynamicOps<Tag>`
+- `net.minecraft.world.level.Level$ExplosionInteraction` now implements `StringRepresentable`
+- `net.minecraft.world.entity.projectile.windcharge.AbstractWindCharge$WindChargeDamageCalculator` -> `net.minecraft.world.level.SimpleExplosionDamageCalculator`
+- `net.minecraft.world.level.block.ButtonBlock#press` now takes in a nullable `Player`
+- `net.minecraft.world.level.block.LeverBlock#pull` now takes in a nullable `Player` and does not return anything
+- `net.minecraft.world.level.storage.loot.LootContext$EntityTarget`
+  - `KILLER` -> `ATTACKER`
+  - `DIRECT_KILLER` -> `DIRECT_ATTACKER`
+  - `KILLER_PLAYER` -> `ATTACKING_PLAYER`
+- `net.minecraft.world.level.storage.loot.functions.CopyNameFunction$NameSource`
+  - `KILLER` -> `ATTACKING_ENTITY`
+  - `KILLER_PLAYER` -> `LAST_DAMAGE_PLAYER`
+- `net.minecraft.world.level.storage.loot.parameters.LootContextParams`
+  - `KILLER_ENTITY` -> `ATTACKING_ENTITY`
+  - `DIRECT_KILLER_ENTITY` -> `DIRECT_ATTACKING_ENTITY`
+- `net.minecraft.world.level.storage.loot.predicates.LootItemConditions#TYPED_CODEC`, `DIRECT_CODEC`, `CODEC` have been moved to `LootItemCondition`
+- `net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceWithLootingCondition` -> `LootItemRandomChanceWithEnchantedBonusCondition`
+- `net.minecraft.world.phys.shapes.VoxelShape#getCoords` is now public
+- `net.minecraft.advancements.critereon.DamageSourcePredicate` now takes in a boolean of if the damage source is direct
+- `net.minecraft.client.gui.components.SubtitleOverlay$Subtitle` is now package private
+- `net.minecraft.network.protocol.game.ClientboundProjectilePowerPacket` takes in an `accelerationPower` double instead of power for each of the coordinate components
+- `net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket#get*a` now provides the double representing the actual acceleration vector of the coordinate instead of the shifted integer
+- `net.minecraft.world.damagesource.DamageSource#isIndirect` has been replaced with `isDirect`, which does the opposite check
+- `net.minecraft.world.entity.Entity#push` now contains an overload that takes in a `Vec3`
+- `net.minecraft.world.entity.LivingEntity#eat` is now final
+    - A separate overload taking in the `FoodProperties` can now be overridden
+- `net.minecraft.world.entity.ai.attributes.AttributeMap#getDirtyAttributes` -> `getAttributestoUpdate`
+- `net.minecraft.world.entity.animal.frog.Tadpole#HITBOX_WIDTH`, `HITBOX_HEIGHT` is now final
+- `net.minecraft.world.entity.npc.AbstractVillager#getOffers` now throws an error if called on the logical client
+- `net.minecraft.world.entity.projectile.AbstractHurtingProjectile` constructors now take in `Vec3` to assign the directional movement of the acceleration power rather than the coordinate powers
+    - `ATTACK_DEFLECTION_SCALE` -> `INITIAL_ACCELERATION_POWER`
+    - `BOUNCE_DEFELECTION_SCALE` -> `DEFLECTION_SCALE`
+    - `xPower`, `yPower`, `zPower` -> `accelerationPower`
+- `net.minecraft.world.food.FoodData#eat(ItemStack)` -> `eat(FoodProperties)`
+- `net.minecraft.world.food.FoodProperties` now takes in a stack representing what the food turns into once eaten
+- `net.minecraft.world.item.CrossbowItem#getChargeDuration` no longer takes in an `ItemStack`
+- `net.minecraft.world.item.ItemStack`
+    - `transmuteCopy` now has an overload which takes in the current count
+    - `transmuteCopyIgnoreEmpty` is now private
+- `net.minecraft.world.level.ChunkPos#getChessboardDistance` now has an overload to take in the x and z coordinates without being wrapped in a `ChunkPos`
+- `net.minecraft.world.level.block.LecternBlock#tryPlaceBook` now takes in a `LivingEntity` instead of an `Entity`
+- `net.minecraft.world.level.block.entity.CampfireBlockEntity#placeFood` now takes in a `LivingEntity` instead of an `Entity`
+- `net.minecraft.world.level.chunk.ChunkAccess#getStatus` -> `getPersistedStatus`
+- `net.minecraft.world.level.chunk.ChunkGenerator#createBiomes`, `fillFromNoise` no longer takes in an `Executor`
+- `net.minecraft.world.level.levelgen.structure.pools.JigsawPlacement#addPieces` now takes in a `DimensionPadding` when determining the starting generation point
+- `com.mojang.blaze3d.systems.RenderSystem`
+    - `glBindBuffer(int, IntSupplier)` -> `glBindBuffer(int, int)`
+    - `glBindVertexArray(Supplier<Integer>)` -> `glBindVertexArray(int)`
+    - `setupOverlayColor(IntSupplier, int)` -> `setupOverlayColor(int, int)`
+- `net.minecraft.advancements.critereon.EntityPredicate#location`, `steppingOnLocation` has been wrapped into a `$LocationWrapper` subclass
+    - This does not affect currently generated entity predicates
+- `net.minecraft.client.Options#menuBackgroundBlurriness`, `getMenuBackgroundBlurriness` now returns an integer
+- `net.minecraft.client.renderer.GameRenderer#MAX_BLUR_RADIUS` is now public and an integer
+- `net.minecraft.gametest.framework.GameTestHelper#getBlockEntity` now throws an exception if the block entity is missing
+- `net.minecraft.network.protocol.game.ServerboundUseItemPacket` now takes in the y and x rotation of the item
+- `net.minecraft.server.level.ServerLevel#addDuringCommandTeleport`, `#addDuringPortalTeleport` have been combined into `addDuringTeleport` by checking whether the entity is a `ServerPlayer`
+- `net.minecraft.server.level.ServerPlayer#seenCredits` is now public
+- `net.minecraft.server.players.PlayerList#respawn` now takes in an `Entity$RemovalReason`
+- `net.minecraft.world.effect.OozingMobEffect#numberOfSlimesToSpawn(int, int, int)` -> `numberOfSlimesToSpawn(int, NearbySlimes, int)`
+- `net.minecraft.world.entity.Entity`
+    - `setOnGroundWithKnownMovement` -> `setOnGroundWithMovement`
+    - `getBlockPosBelowThatAffectsMyMovement` is now public
+- `net.minecraft.world.entity.EquipmentSlot` now takes in an integer represent the max count the slot can have, or 0 if unrestricted
+    - Can be applied via `limit` which splits the current item stack
+- `net.minecraft.world.entity.LivingEntity`
+    - `dropAllDeathLoot`, `dropCustomDeathLoot` now takes in a `ServerLevel`
+    - `broadcastBreakEvent` -> `onEquippedItemBroken`
+    - `getEquipmentSlotForItem` is now an instance method
+- `net.minecraft.world.entity.ai.attributes.AttributeMap#assignValues` -> `assignAllValues`
+- `net.minecraft.world.entity.raid.Raider#applyRaidBuffs` now takes in a `ServerLevel`
+- `net.minecraft.world.item.ItemStack#hurtAndBreak` now takes in a `Consumer` of the broken `Item` instead of a `Runnable`
+- `net.minecraft.CrashReport`
+    - `getFriendlyReport` and `saveToFile` now takes in a `ReportType` and a list of header strings
+        - There is also an overload that just takes in the `ReportType`
+    - `getSaveFile` now returns a `Path`
+- `net.minecraft.client.gui.screens.DisconnectedScreeen` can now take in a record containing the disconnection details
+    - `DisConnectionDetails` provide an optional path to the report and an optional string to the bug report link
+- `net.minecraft.client.renderer.LevelRenderer#playStreamingMusic` -> `playJukeboxSong`
+    - `stopJukeboxSongAndNotifyNearby` stops playing the current song
+- `net.minecraft.client.resources.sounds.SimpleSoundInstance#forRecord` -> `forJukeboxSong`
+- `net.minecraft.client.resources.sounds.Sound` now takes in a `ResourceLocation` instead of a `String`
+- `net.minecraft.network.PacketListener`
+    - `onDisconnect` now takes in `DisconnectionDetails` instead of a `Component`
+    - `fillListenerSpecificCrashDetails` now takes in a `CrashReport`
+- `net.minecraft.server.MinecraftServer`
+    - `getServerDirectory`, `getFile` now returns a `Path`
+    - `isNetherEnabled` -> `isLevelEnabled`
+- `net.minecraft.world.entity.ai.behavior.AnimalPanic` now takes in a `Function<PathfinderMob, TagKey<DamageType>>` instead of a simple `Predicate`
+- `net.minecraft.world.entity.ai.goal.FollowOwnerGoal` no longer takes in a boolean checking whether the entity can fly
+    - These methods have been moved to `TamableAnimal`
+- `net.minecraft.world.entity.ai.goal.PanicGoal` now takes in a `Function<PathfinderMob, TagKey<DamageType>>` instead of a simple `Predicate`
+- `net.minecraft.world.entity.projectile.Projectile#deflect` now returns a boolean indicating whether the deflection was successful
+- `net.minecraft.world.item.CreativeModeTabe#getBackgroundSuffix` -> `getBackgroundTexture`
+- `net.minecraft.world.item.DyeColor#getTextureDiffuseColors` -> `getTextureDiffuseColor`
+- `net.minecraft.world.level.block.entity.BeaconBlockEntity$BeaconBeamSection#getColor` now returns an integer
+- `net.minecraft.world.level.storage.loot.LootDataType` no longer takes in a directory, instead it grabs that from the location of the `ResourceKey`
+- `net.minecraft.client.gui.screens.Scnree#narrationEnabled` -> `updateNarratorStatus(boolean)`
+- `net.minecraft.client.gui.screens.inventory.HorseInventoryScreen` takes in an integer representing the number of inventory columns to display
+- `net.minecraft.client.renderer.block.model.BlockElementFace` is now a record
+- `net.minecraft.client.resources.model.ModelBakery#getModel` is now package-private
+- `net.minecraft.client.resources.model.ModelResourceLocation` is now a record
+    - `inventory` method for items
+- `net.minecraft.client.resources.model.UnbakedModel#bakeQuad` no longer takes in a `ResourceLocation`
+- `net.minecraft.core.BlockMath#getUVLockTransform` no longer takes in a `Supplier<String>`
+- `net.minecraft.gametest.framework.GameTestBatchFactory#toGameTestBatch` is now public
+- `net.minecraft.gametest.framework.GameTestRunner` now takes in a boolean indicating whether to halt on error
+- `net.minecraft.network.protocol.ProtocolInfoBuilder`
+    - `serverboundProtocolUnbound` -> `serverboundProtocol`
+    - `clientboundProtocolUnbound` -> `clientboundProtocol`
+- `net.minecraft.network.protocol.game.ClientboundAddEntityPacket` now takes in the `ServerEntity` for the first two packet constructors
+- `net.minecraft.server.MinecraftServer` now implements `ChunkIOErrorReporter`
+- `net.minecraft.util.ExtraCodecs#QUATERNIONF_COMPONENTS` now normalizes the quaternion on encode
+- `net.minecraft.world.entity.Entity#getAddEntityPacket` now takes in a `ServerEntity`
+- `net.minecraft.world.entity.Mob` leash methods have been moved to `Leashable`
+- `net.minecraft.world.entity.Saddleable#equipSaddle` now takes in the `ItemStack` being equipped
+- `net.minecraft.world.entity.ai.village.poi.PoiManager` now takes in a `ChunkIOErrorReporter`
+- `net.minecraft.world.level.chunk.storage.ChunkSerializer#read` now takes in a `RegionStorageInfo`
+- `net.minecraft.world.level.chunk.storage.SectionStorage` now takes in a `ChunkIOErrorReporter`
+- `net.minecraft.world.level.levelgen.structure.PoolElementStructurePiece` now takes in `LiquidSettings`
+- `net.minecraft.world.level.levelgen.structure.pools.JigsawPlacement#addPieces` now takes in `LiquidSettings`
+- `net.minecraft.world.level.levelgen.structure.pools.SinglePoolElement` now takes in an `Optional<LiquidSettings>`
+    - `getSettings` now takes in `LiquidSettings`
+- `net.minecraft.world.level.levelgen.structure.pools.StructurePoolElement` now takes in an `LiquidSettings`
+    - `single` also has overloads that takes in `LiquidSettings`
+- `net.minecraft.world.level.levelgen.structure.structures.JigsawStructure` now takes in `LiquidSettings`
+- `net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings#shouldKeepLiquids` -> `shouldApplyWaterlogging`
+- `net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager#getPathToGeneratedStructure`, `createPathToStructure` -> `createAndValidatePathToGeneratedStructure`
+- `net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceWithEnchantedBonusCondition` now takes in a float representing the chance to unenchant the item
+- `net.minecraft.world.phys.shapes.CubePointRange`'s constructor is now public
+- `net.minecraft.world.phys.shapes.VoxelShape`'s constructor is now protected
+- `net.minecraft.client.gui.components.Checkbox` now takes in a max width which can be passed in through the builder via `Checkbox$Builder#maxWidth`
+- `net.minecraft.client.gui.components.MultiLineLabel`
+    - `create` methods with `FormattedText` has been removed
+    - `create` methods with `List`s now take in a component varargs
+    - `createFixed` -> `create`
+    - `renderCentered`, `renderLeftAligned` no longer return anything
+    - `renderBackgroundCentered` is removed
+    - `TextAndWidth` is now a record
+- `net.minecraft.commands.arguments.selector.EntitySelector#predicate` -> `contextFreePredicate`
+    - Takes in a `List<Predicate<Entity>>` now
+- `net.minecraft.world.level.border.WorldBorder`
+    - `isWithinBounds` now has overloads for `Vec3` and four doubles representing two xz coordinates
+    - `clampToBounds` now has overloads for `BlockPos` and `Vec3`
+    - `clampToBounds(AABB)` is removed
+- `net.minecraft.server.level.ServerPlayer#onInsideBlock` is now public, only for this overload
+
+### Removed
+
+- `net.minecraft.client.Minecraft`
+    - `getSearchTree`, `populateSearchTree`
+    - `renderOnThread`
+- `net.minecraft.client.searchtree.SearchRegistry`
+- `net.minecraft.entity.LivingEntity#canSpawnSoulSpeedParticle`, `spawnSoulSpeedParticle`
+- `net.minecraft.world.entity.projectile.AbstractArrow`
+  - `setKnockback`, `getKnockback`
+  - `setShotFromCrossbow`
+- `net.minecraft.world.item.ProjectileWeaponItem#hasInfiniteArrows`
+- `com.mojang.blaze3d.systems.RenderSystem`
+    - `initGameThread`, `isOnGameThread`
+    - `assertInInitPhase`, `isInInitPhase`
+    - `assertOnGameThreadOrInit`, `assertOnGameThread`
+- `net.minecraft.client.gui.screens.Screen#advancePanoramaTime`
+- `net.minecraft.world.entity.EquipmentSlot#byTypeAndIndex`
+- `net.minecraft.world.entity.Mob#canWearBodyArmor`
+    - Use `canUseSlot(EquipmentSlot.BODY)` instead
+- `com.mojang.blaze3d.platform.MemoryTracker`
+- `net.minecraft.server.level.ServerLevel#makeObsidianPlatform`
+- `net.minecraft.world.entity.Entity#getPassengerClosestTo`
+- `net.minecraft.client.resources.model.ModelBakery$ModelGroupKey`
+- `net.minecraft.data.worldgen.Structures#structure`

--- a/primers/1.21/index.md
+++ b/primers/1.21/index.md
@@ -4,7 +4,7 @@ This is a high level, non-exhaustive overview on how to migrate your mod from 1.
 
 This primer is licensed under the [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/), so feel free to use it as a reference and leave a link so that other readers can consume the primer.
 
-If there's any incorrect or missing information, please leave a comment below. Thanks!
+If there's any incorrect or missing information, please file an issue on this repository or ping @ChampionAsh5357 in the Neoforged Discord server.
 
 ## Pack Changes
 

--- a/primers/LICENSE
+++ b/primers/LICENSE
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/primers/README.md
+++ b/primers/README.md
@@ -1,0 +1,23 @@
+# Primers
+
+The primers in this repository are meant to provide a high level, non-exhaustive overview on mirgating a mod between two Minecraft versions. Each subdirectory represents the version the primer is written for. The main `index` file contains vanilla changes while mod loader changes are in a file with its name.
+
+The primers were written by [@ChampionAsh5357](https://github.com/ChampionAsh5357).
+
+## Versions
+
+* [1.19.2 -> 1.19.3](./1.19.3/index.md)
+    * [Forge Changes](./1.19.3/forge.md)
+* [1.19.3 -> 1.19.4](./1.19.4/index.md)
+    * [Forge Changes](./1.19.4/forge.md)
+* [1.19.4 -> 1.20](./1.20/index.md)
+    * [Forge Changes](./1.20/forge.md)
+* [1.20.4 -> 1.20.5](./1.20.5/index.md)
+* [1.20.5 -> 1.20.6](./1.20.6/index.md)
+* [1.20.6 -> 1.21](./1.21/index.md)
+
+## License
+
+The primers in this directory are under the copyright of [@ChampionAsh5357](https://github.com/ChampionAsh5357) and licensed under the Creative Commons Attribution 4.0 International.
+
+See [the Creative Commons website](https://creativecommons.org/licenses/by/4.0/) for additional details, and see the `LICENSE` file in this directory for the full license text.


### PR DESCRIPTION
Adds all previous primers into `primers/<release_version>/` `index.md` is used for vanilla changes while `<mod_loader>.md` is used for changes within the specified mod loader.