### PR TITLE
Create a maintainers specific file for guidelines

### DIFF
--- a/teams/MAINTAINERS.md
+++ b/teams/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 This document aims to clarify policies and recommendations by which the Maintainer team operates. The goal is to help Maintainers understand what is expected of them and recommendations of how to reduce the chances of conflict within the Maintainer team. It also serves as a launch point for new maintainers to jump into how the team operates.
 
-Each repository in the organization may have its own specific workflow. See documentation in the respective repository for details, or reach out to team members who have previously worked on those repositories. For our main repository, see the [docs folder](https://github.com/neoforged/NeoForge/tree/1.21.x/docs).
+- Each repository in the organization may have its own specific workflow. See documentation in the respective repository for details, or reach out to team members who have previously worked on those repositories. For our main repository, see the [docs folder](https://github.com/neoforged/NeoForge/tree/1.21.x/docs).
 
 - Keep other maintainers in the loop before merging an impactful PR by pinging `@Maintainers` in the `#maintenance-talk` Discord channel. If you aren't sure whether a PR is impactful, it's better to assume that it is.
 


### PR DESCRIPTION
Slicing up this original governance PR:
https://github.com/neoforged/governance/pull/20

The parts that made it to this PR that are not specific to any project are 

- how maintainers should review project's CONTRIBUTING.md/README.md files for project specific policies
- maintainers should communicate large works to rest of team as a suggestion for better communication and collaboration

This will help contributors and new maintainers to get up to speed on NeoForge a bit faster now