### PR TITLE
Cleanup old primers

### DIFF
--- a/primers/1.14/index.md
+++ b/primers/1.14/index.md
@@ -112,7 +112,7 @@ Here's the extremely quick rundown. Assumes prior knowledge of blockstates:
 
 * Read https://mcforge.readthedocs.io/en/1.13.x/utilities/tags/
 * Remember: Block tags (`tags/blocks/...`)are only used for commands like /execute which query the blocks in world directly. Advancements and recipes both operate on *ItemBlock*s and use *item* tags (`tags/items/...`). Yes this will result in some duplication. If you're lazy, you can skip out on the block tags since the item tags are much more important, but doing them is still recommended for good compatibility.
-      * For example, mods which have in-world recipes like Botania might want to use block tags. In <1.13 such mods must slowly iterate the OreDictionary (which is built for items, not blocks) and/or perform caching logic. With block tags, it would just be a constant time set lookup.
+      * For example, mods which have in-world recipes like Botania might want to use block tags. Prior to 1.13 such mods must slowly iterate the OreDictionary (which is built for items, not blocks) and/or perform caching logic. With block tags, it would just be a constant time set lookup.
 
 ## Recipes
 * You need a json for every recipe now (*dramatic music plays*)
@@ -268,7 +268,7 @@ you implemented the necessary method in your IParticleData Deserializer.
 * Biome ids are internally ints now instead of bytes, which raises the maximum number of allowed biomes from 255 to 2 billion.
 * Enchantments are now stored by registry name instead of int id (about time...)
 * A word about integer ID's
-  * For Items and Blocks, you should have already switched  to fully using registry names for everything. The registry name <-> int ID maps still exist in vanilla for performance purposes, but they should *never* be used for anything other than network communication because they are NOT guaranteed to be the same after joining a different world. This should already be an established modding convention since 1.8, but people still break it, so I'll mention it again :P
+  * For Items and Blocks, you should have already switched  to fully using registry names for everything. The registry name to int ID maps still exist in vanilla for performance purposes, but they should *never* be used for anything other than network communication because they are NOT guaranteed to be the same after joining a different world. This should already be an established modding convention since 1.8, but people still break it, so I'll mention it again :P
 * There's lots of superinterfaces on world now representing different things you can do (e.g. there's an interface for read-only access to the world). If possible, try using the least specific one.
 * Most nameable things that still used strings now use text components, so translate all the things!
 * There's multiple kinds of air block now (air, void_air, and cave_air). So if you're doing == Blocks.AIR checks still, change them to IBlockState.isAir checks

--- a/primers/1.16.5/index.md
+++ b/primers/1.16.5/index.md
@@ -33,7 +33,7 @@ There are also some flaws with certain Codec types which can cause unintended is
 
 For example, the UnboundedMapCodec is highly sensitive when it encounters errors, and will discard all entries prior to an erroring entry, even if those entries were not erroring.
 
-This is a big issue for some implementations, as seen in cases like <a href="https://bugs.mojang.com/browse/MC-197860">MC-197860</a>, in which the cause was due to the error handling behaviour of UnboundedMapCodec.
+This is a big issue for some implementations, as seen in cases like [MC-197860](https://bugs.mojang.com/browse/MC-197860), in which the cause was due to the error handling behaviour of UnboundedMapCodec.
 
 
 ## Dynamic Registries
@@ -55,7 +55,7 @@ Otherwise, it is recommended to use a JSON file.
 During runtime you can get an object from a dynamic registry from either the MinecraftServer or the ClientPlayNetHandler, depending on the logical side you are on.
 
 E.g. 
-```
+```java
 RegistryKey<Biome> myBiomeRegistryKey = RegistryKey.get(new ResourceLocation(MODID, "test_biome"));
 
 Biome biome = serverWorld.getServer().registryAccess().registryOrThrow(Registry.BIOME).get(myBiomeRegistryKey);
@@ -77,7 +77,7 @@ For example, a Biome object has a RegistryKey which is made up of the biome and 
 
 The Biome Registry itself also has a RegistryKey, which is made up of a registry name and the Biome Registry. 
 
-E.g. ``RegistryKey<Biome> testBiomeKey = RegistryKey.get(Registry.BIOME, new ResourceLocation(MODID, "test_biome"));``
+E.g. `RegistryKey<Biome> testBiomeKey = RegistryKey.get(Registry.BIOME, new ResourceLocation(MODID, "test_biome"));`
 
 ### Usage
 
@@ -95,11 +95,11 @@ While some objects still require code based objects, most world generation is no
 This may seem like a surprise for some as in all previous versions, it was code based. 
 This is because large breaking changes were made in a MINOR version, 1.16.2. 
 
-It is possible these changes were originally part of the initial 1.16 release, but had to be delayed for other reaons.
+It is possible these changes were originally part of the initial 1.16 release, but had to be delayed for other reasons.
 
 We can expect this to happen in future minor versions, though it is unlikely that they will introduce changes on this scale often.
 
-### Registriation Process Changes
+### Registration Process Changes
 With the move to data-driven registries, it is important to know how world generation objects are registered in the new system.
 
 There are now 2 types of registries for World generation objects:
@@ -141,9 +141,9 @@ One exception for code-based biome objects is for making dummy objects to take u
 #### Biome Registration
 You no longer use the Forge Registry for new Biomes. It is recommended to use datapack jsons to do this.
 
-Make a json file named with the registry name of your biome in ``data/your_modid/worldgen/biome``
+Make a json file named with the registry name of your biome in `data/your_modid/worldgen/biome`
 
-E.g. ``data/modid/worldgen/biome/my_test_biome.json``
+E.g. `data/modid/worldgen/biome/my_test_biome.json`
 
 Vanilla will automatically pickup and register the json during datapacks loading.
 
@@ -157,10 +157,10 @@ E.g. We want to add a ConfiguredStructureFeature to an existing biome.
 2. Register the code-based object to WorldGenRegistries during FMLCommonSetupEvent in an enqueueWork lambda function to make this call thread-safe.
 3. Add the code-based object to the BiomeLoadingEvent provided by Forge.
 
-In the event, to check for a specific biome, make a RegistryKey<Biome> instance using the event's biome registry name, and compare this registry key to another registry key.
+In the event, to check for a specific biome, make a `RegistryKey<Biome>` instance using the event's biome registry name, and compare this registry key to another registry key.
 
 e.g. 
-```
+```java
 @SubscribeEvent(priority = EventPriority.HIGH)
 public static void onBiomeLoad(BiomeLoadingEvent event) 
 {
@@ -191,9 +191,9 @@ Then, call BiomeManager#addAdditionalOverworldBiomes in FMLCommonSetupEvent in a
 You can use the RegistryKey you made earlier in this method.
 
 E.g.
-```
+```java
 
-public static final RegistryKey<Biome> testBiomeKey = RegistryKey.get(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "test_biome));
+public static final RegistryKey<Biome> testBiomeKey = RegistryKey.get(Registry.BIOME_REGISTRY, new ResourceLocation(MODID, "test_biome"));
 
 public void commonSetup(FMLCommonSetupEvent event)
 {
@@ -205,7 +205,7 @@ public void commonSetup(FMLCommonSetupEvent event)
 
 The data driven systems are still a bit over the place in some areas so some of these workarounds are necessary.
 
-To add biomes to your custom dimensions, you can add the biome's registry name to the dimension json. i.e. ``"modid:my_biome"``
+To add biomes to your custom dimensions, you can add the biome's registry name to the dimension json. i.e. `"modid:my_biome"`
 
 #### Biome Properties
 
@@ -216,7 +216,7 @@ Some of these changes, documented by community member SuperCoder797, is as follo
 - Fog color specified in the effects will only work in the Nether. It won't work in the Overworld.
 - You can now have particles spawn in biomes, this works for both the nether and the overworld. You can make some cool stuff with this, like flying sand in desert biomes.
 - Sounds can also be specified per biome, and you can specify 3 different sound types.
-- Loop sounds are continously played when a player is in the biome (useful for ocean waves on beaches).
+- Loop sounds are continuously played when a player is in the biome (useful for ocean waves on beaches).
 - Mood sounds are played when the player is in an area with 0 sky light and less than 7 light. Overworld biomes use the cave sounds as mood sounds while the nether biomes have their own unique variants.
 - Additions sounds have a 1.1% chance to play every tick. The nether biomes use these to add to their atmosphere, but you can probably use them for other stuff in the overworld, like bird sounds or something.
 - Now have a new field for BiomeContainer, which are theoretical points on a 4d plane used for biome calculation in the Nether.
@@ -224,7 +224,7 @@ Some of these changes, documented by community member SuperCoder797, is as follo
 
 #### Referencing a Biome (Forge)
 
-In this new environment the Biome's ``getRegistryName`` method added by IForgeRegistry CAN NOW BE NULL.
+In this new environment the Biome's `getRegistryName` method added by IForgeRegistry CAN NOW BE NULL.
 
 When getting an instance of a biome, always use a RegistryKey to get the value from the Biome Registry in the DynamicRegistries.
 
@@ -268,7 +268,7 @@ Some edge cases require special handling.
 
 A notable example is the SingleBiomeProvider.
 
-For example, if your ChunkGenerator uses the SingleBiomeProvider, you may notice that the SingleBiomeProvider does not properly get biomes from the ``Biome.CODEC``. 
+For example, if your ChunkGenerator uses the SingleBiomeProvider, you may notice that the SingleBiomeProvider does not properly get biomes from the `Biome.CODEC`. 
 SingleBiomeProvider also contains a bug that doesn't allow Biome colours to be sent the client properly.
 
 One workaround is to use a MultiBiomeProvider and supply a single biome to it, as MultiBiomeProvider does not have those problems.
@@ -287,24 +287,24 @@ It also needs to be registered to WorldGenRegistries to prevent it from overridi
 
 Registering a Structure requires you to add it to a number of different objects.
 
-Additionally, some of the new backend changes have become more hardcoded in approach, which requires modders to use work arounds.
+Additionally, some of the new backend changes have become more hardcoded in approach, which requires modders to use work around.
 
 - ConfiguredStructureFeature(s) MUST be registered to the WorldGenRegistries after registry events have fired. If this is not done your structure will prevent other mod structures from spawning.
-- Structures must be added to ``Structure.STRUCTURES_REGISTRY`` so the game is aware of the structure when it is used in other contexts. This also ensures the /locate command will list your structure.
-- We also need to add to ``FlatGenerationSettings.STRUCTURES`` to prevent any sort of crash or issue with other mod's custom ChunkGenerators.
+- Structures must be added to `Structure.STRUCTURES_REGISTRY` so the game is aware of the structure when it is used in other contexts. This also ensures the /locate command will list your structure.
+- We also need to add to `FlatGenerationSettings.STRUCTURES` to prevent any sort of crash or issue with other mod's custom ChunkGenerators.
 - The StructureSeparationSettings also needs to added to a world's ChunkGenerator to allow the chunk generator to know how many chunks it should iterate over before spawning the structure. Without this, the structure simply won't generate.
-- However, if mods want to change the StructureSeparationSettings dynamically, they must construct the seperation settings while a world is loading, because a chunk generator won't know which world it is binded to.
+- However, if mods want to change the StructureSeparationSettings dynamically, they must construct the seperation settings while a world is loading, because a chunk generator won't know which world it is bound to.
 
-A community member, TelepathicGrunt has kindly shared a working solution that shows <a href="https://github.com/TelepathicGrunt/StructureTutorialMod">how to register a structure in the Forge Environment</a>.
+A community member, TelepathicGrunt has kindly shared a working solution that shows [how to register a structure in the Forge Environment](https://github.com/TelepathicGrunt/StructureTutorialMod).
 
 The summary of their solution is as follows
 
-1. In the Mod Constructor Register a ``Structure<?>`` instance to the ``STRUCTURE_FEATURES`` Forge registry so the registry IDs are safely taken up.
-2. In FMLCommonSetupEvent, add the structure to ``Structure.STRUCTURES_REGISTRY`` in an enqueueWork lambda. This is necessary to allow MC to know about the structure and to allow the /locate command to work for this structure.
+1. In the Mod Constructor Register a `Structure<?>` instance to the `STRUCTURE_FEATURES` Forge registry so the registry IDs are safely taken up.
+2. In FMLCommonSetupEvent, add the structure to `Structure.STRUCTURES_REGISTRY` in an enqueueWork lambda. This is necessary to allow MC to know about the structure and to allow the /locate command to work for this structure.
 3. In FMLCommonSetupEvent, add the ConfiguredStructureFeature to WorldGenRegistries in an enqueueWork lambda to prevent it from overriding other modded structures.
-4. In FMLCommonSetupEvent, add a StructureSeparationSettings to ``DimensionStructuresSettings.DEFAULTS`` to allow the structure's seperation settings to be registered. (This field is an immutable map so it needs some non-api modding methods like Mixins/AccessTransformers/Reflection to access it).
-5. In FMLCommonSetupEvent, add the ConfiguredStructureFeature instance to ``FlatGenerationSettings.STRUCTURES`` to prevent any sort of crash or issue with other mod's custom ChunkGenerators.
-6. (Optional) If we want the structure to seamlessly merge with terrain like Villages, add the structure to ``Structure.NOISE_AFFECTING_FEATURES`` in FMLCommonSetupEvent.
+4. In FMLCommonSetupEvent, add a StructureSeparationSettings to `DimensionStructuresSettings.DEFAULTS` to allow the structure's seperation settings to be registered. (This field is an immutable map so it needs some non-api modding methods like Mixins/AccessTransformers/Reflection to access it).
+5. In FMLCommonSetupEvent, add the ConfiguredStructureFeature instance to `FlatGenerationSettings.STRUCTURES` to prevent any sort of crash or issue with other mod's custom ChunkGenerators.
+6. (Optional) If we want the structure to seamlessly merge with terrain like Villages, add the structure to `Structure.NOISE_AFFECTING_FEATURES` in FMLCommonSetupEvent.
 7. In the WorldEvent.Load event, add the structure to ChunkGenerator of the world you want to add the structure to. This allows modders to blacklist structures from spawning in specific worlds, as well allowing users to configure the StructureSeparationSettings via Config files.
 8. In the BiomeLoadingEvent, add the ConfiguredStructureFeature instance to our biome of choice if we want to structure to spawn in an existing biome.
 
@@ -315,7 +315,7 @@ Please note that this approach does not use proper Forge API hooks as the hooks 
 Features need to be code-based if we want to add them to existing biomes.
 It also needs to be registered to WorldGenRegistries to prevent it from overriding other modded features.
 
-1. In the Mod Constructor Register a Feature<?> instance to the ``FEATURES`` Forge registry so the registry IDs are safely taken up.
+1. In the Mod Constructor Register a `Feature<?>` instance to the `FEATURES` Forge registry so the registry IDs are safely taken up.
 2. In FMLCommonSetupEvent, add the ConfiguredFeature to WorldGenRegistries in an enqueueWork lambda to prevent it from overriding other modded structures.
 3. In the BiomeLoadingEvent, add the ConfiguredFeature instance to the biome if we want to feature to spawn in an existing biome.
 
@@ -323,11 +323,11 @@ It also needs to be registered to WorldGenRegistries to prevent it from overridi
 
 This has been refactored once again.
 
-It has now been flattened and split into ``FoliagePlacer``s, ``TrunkPlacer``s, and ``FeatureSize``s.
+It has now been flattened and split into `FoliagePlacer`s, `TrunkPlacer`s, and `FeatureSize`s.
 
-A summarised proccess of generating is as follows (referenced from SuperCoder7979):
+A summarised process of generating is as follows (referenced from SuperCoder7979):
 1. First, the tree's FeatureSize checks if it can spawn in a given position.
-2. TrunkPlacerss then generate the trunk and then generate places for leaves to generate through ``FoliageAttachment``s.
+2. TrunkPlacers then generate the trunk and then generate places for leaves to generate through `FoliageAttachment`s.
 3. For each FoliageAttachment, the tree's FoliagePlacer generates its leaves.
 4. If you have FoliagePlacers from 1.15, it is recommended that those are rewritten entirely.
 
@@ -336,33 +336,33 @@ A summarised proccess of generating is as follows (referenced from SuperCoder797
 ### Dimension
 Dimensions are now data-driven and have significantly changed in its design.
 
-- Dimensions are now more of a set of extended settings for a World. It pairs a ChunkGenerator and DimensionType togethor. (World = Level and Dimension = LevelStem in Mojang mappings)
+- Dimensions are now more of a set of extended settings for a World. It pairs a ChunkGenerator and DimensionType together. (World = Level and Dimension = LevelStem in Mojang mappings)
 - Dimensions now have a One to Many Relationship with a DimensionType, meaning you can now have many Dimensions using the same DimensionType.
 - Dimensions now have a One to One relationship with a World, meaning the World itself is the instance of a Dimension.
 
-Forge's DimensionManager class has also been removed due to it being obselete in this new environment.
+Forge's DimensionManager class has also been removed due to it being obsolete in this new environment.
 
 #### Registration
 
 Custom dimensions/worlds should no longer be made in code except for special cases like dynamically created dimensions during runtime.
 
-Create a JSON file in ``data/modid/dimension/`` to register and define your dimension.
+Create a JSON file in `data/modid/dimension/` to register and define your dimension.
 
 Vanilla will automatically pickup and register this dimension/world during datapack loading whilst also creating the world for the data-driven dimension during world creation.
 
 #### Referencing a Dimension
 
-A Dimension/World is now referenced via a ``RegistryKey<World>`` instance instead of the DimensionType.
+A Dimension/World is now referenced via a `RegistryKey<World>` instance instead of the DimensionType.
 
-To get an instance of ``RegistryKey<World>``, use ``RegistryKey.get(Registry.DIMENSION_REGISTRY, new ResourceLocation(MODID, "registry_name_here"))``
+To get an instance of `RegistryKey<World>`, use `RegistryKey.get(Registry.DIMENSION_REGISTRY, new ResourceLocation(MODID, "registry_name_here"))`
 
-To access a ``RegistryKey<World>`` from a world, use ``World#dimension``.
+To access a `RegistryKey<World>` from a world, use `World#dimension`.
 
-To get a World on the server, use MinecraftServer#getWorld, which takes a ``RegistryKey<World>`` as the parameter.
+To get a World on the server, use MinecraftServer#getWorld, which takes a `RegistryKey<World>` as the parameter.
 
-While ``RegistryKey<Dimension>`` may also seem correct, it is merely for internal use.
+While `RegistryKey<Dimension>` may also seem correct, it is merely for internal use.
 
-Use ``RegistryKey<World>`` for most implementations.
+Use `RegistryKey<World>` for most implementations.
 
 #### Getting the Dimension Registry (Vanilla Internal Use Only)
 While the dimension registry is data-driven like other world generation objects, it is NOT in the DynamicRegistries like the others.
@@ -382,7 +382,7 @@ You can make multiple dimensions use the same dimension type.
 
 #### Registration
 
-To make a custom DimensionType, use a JSON file add it to ``data/modid/dimension_type``.
+To make a custom DimensionType, use a JSON file add it to `data/modid/dimension_type`.
 
 ### DimensionRenderInfo
 
@@ -410,7 +410,7 @@ This feature may be restored once a suitable solution is provided to Forge.
 Most rendering methods now include a MatrixStack in their parameters.
 
 ### GUI
-GUIs are an exception in which some methods still use old ``RenderSystem`` and ``GlStateManager`` calls.
+GUIs are an exception in which some methods still use old `RenderSystem` and `GlStateManager` calls.
 
 This is due to when/how the buffer is drawn to the screen, so systems like RenderSystem have become a temporary option until vanilla fully migrates their rendering engine to the batched style.
 
@@ -429,7 +429,7 @@ Register your ReloadListener(s) in Forge's AddReloadListenerEvent event. This ev
 
 Datapacks will reload at least twice in total during the game's loading process.
 
-It will be fired at least once before the server has started, so if you are running syncing packets in your reload listener, be sure to check if the MinecraftServer is not null via ``ServerLifecycleHooks#getCurrentServer`` before running your sync packet code.
+It will be fired at least once before the server has started, so if you are running syncing packets in your reload listener, be sure to check if the MinecraftServer is not null via `ServerLifecycleHooks#getCurrentServer` before running your sync packet code.
 
 ## Entity Attribute Creation and Modification
 
@@ -454,7 +454,7 @@ The player is now sent its own set of registry data via a packet on login:
 ## Miscellaneous
 
 ### Multipart Entity hitboxes
-There is now an <a href="https://github.com/MinecraftForge/MinecraftForge/pull/7554"> Forge API hook </a> that allows you to register multiple hitboxes for your entity, similar to the Ender Dragon.
+There is now an [Forge API hook](https://github.com/MinecraftForge/MinecraftForge/pull/7554) that allows you to register multiple hitboxes for your entity, similar to the Ender Dragon.
 
 ### Forge ChunkManager
 The Forge ChunkManager from older versions has been readded to Forge.
@@ -478,16 +478,16 @@ These include:
 ## Forge API
 
 ### EventBusSubscriber Annotation and Mod IDs
-There has been a newly discovered bug in the ``@EventBusSubscriber`` annotation where the Mod ID that is firing the event is no longer known unless the class that this annotation is used on, also has a ``@Mod`` annotation.
+There has been a newly discovered bug in the `@EventBusSubscriber` annotation where the Mod ID that is firing the event is no longer known unless the class that this annotation is used on, also has a `@Mod` annotation.
 
 This bug will affect all mods which use a specialised class for their events.
 
-To fix this issue, please add your Mod ID to the ``modid=`` field in the annotation to ensure your event fires for your mod.
+To fix this issue, please add your Mod ID to the `modid=` field in the annotation to ensure your event fires for your mod.
 
 Even when the fix for this bug is merged in, it is still recommended to adopt this practice to reduce similar issues in the future.
 
 E.g.
-```
+```java
 @Mod.EventBusSubscriber(modid = MyMod.MODID) //Add your Mod ID to the modid field
 public class ForgeEventHandler{
 
@@ -495,7 +495,7 @@ public class ForgeEventHandler{
 ```
 
 ### Mods.TOML License
-In 1.16.5+ all mods are now required to define the "license" field in their ``mods.toml`` file.
+In 1.16.5+ all mods are now required to define the "license" field in their `mods.toml` file.
 
 This license is to allow modders to define how their mod and its assets can be used by others, such as one from https://choosealicense.com/.
 
@@ -507,9 +507,9 @@ E.g. https://github.com/ExampleModderName/MyExampleModRepo/blob/1.16/LICENSE
 
 #### About
 
-Mojang Mappings (nicknamed Mojmaps by modders) are the official obsfucation mappings provided by the developers of Minecraft, Mojang.
+Mojang Mappings (nicknamed Mojmaps by modders) are the official obfuscation mappings provided by the developers of Minecraft, Mojang.
 
-It is a bridging tool to turn Mojang's obsfucated Minecraft code into human readable names.
+It is a bridging tool to turn Mojang's obfuscated Minecraft code into human readable names.
 
 E.g. func_1234_a_ -> setupHelloWorld
 
@@ -540,7 +540,7 @@ Previously, the legal terms for these mappings were in a state where Forge did n
 
 While there still isn't a guarantee that the use of these mappings are legally safe, Forge has now decided to adopt them in good faith that Mojang wants them to use it.
 
-Read more about <a href="https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md">Forge's stance here.</a>
+Read more about [Forge's stance here.](https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md)
 
 #### Pros and Cons
 
@@ -556,19 +556,19 @@ In the latest 1.16.5 Forge Mod Developer Kits (MDKs) Mojang mappings are automat
 ##### Existing Mods
 You can still use the MCP names if you so wish, there are updated MCP mappings made by the community, but these exports are not done very often.
 
-If you choose to upgrade to Mojang Mappings, there is a handy ```upgradeMappings``` Gradle command that can convert existing mapping names to Mojang names, and vice versa.
+If you choose to upgrade to Mojang Mappings, there is a handy `upgradeMappings` Gradle command that can convert existing mapping names to Mojang names, and vice versa.
 
 A summary of updating existing mods to Mojang Mappings is as follows (Referenced from Forge Discord, !updateMappings Bot command):
 1. Make a backup! If you're not already using some form of Version Control System (VCS) or have uncommitted changes, it's important to make a backup. The steps outlined below do not backup your files, and they irreversibly change them. Be warned. Note that you can switch back mappings at any time, but backups are still not made. 
-2. Run ``gradlew -PUPDATE_MAPPINGS_CHANNEL="official" -PUPDATE_MAPPINGS="1.16.5" updateMappings`` in a terminal in your mod's project directory. Prepend ./ if you're using a Unix-based system. 
+2. Run `gradlew -PUPDATE_MAPPINGS_CHANNEL="official" -PUPDATE_MAPPINGS="1.16.5" updateMappings` in a terminal in your mod's project directory. Prepend ./ if you're using a Unix-based system. 
 3. Wait for the process to finish. 
-4. Update your mappings in your build.gradle and/or gradle.properties file and change the mappings line to match something similar to this effect: ``mappings channel: "official", version: "1.16.5"`` 
+4. Update your mappings in your build.gradle and/or gradle.properties file and change the mappings line to match something similar to this effect: `mappings channel: "official", version: "1.16.5"` 
 5. Refresh or reimport your Gradle project. 
 6. Done! Please note that there are still some bugs associated with changing your mappings. Make sure to try building your mod project or running it to see if there are any compilation errors and fix them. 
 
-Note: You can run !updatemappings <mappings channel> to get help switching to another channel. ﻿
+Note: You can run `!updatemappings <mappings channel>` to get help switching to another channel.
 
-Read <a href="https://gist.github.com/JDLogic/bf16deed3bcf99bd9e1a22eb21148389">more about the updateMappings command here. </a> 
+Read [more about the updateMappings command here.](https://gist.github.com/JDLogic/bf16deed3bcf99bd9e1a22eb21148389) 
 
 ### Mixins in Forge!
 #### About
@@ -615,8 +615,8 @@ DO NOT use this event for your mods.
 
 ## References
 
-- <a href="https://gist.github.com/SuperCoder7979/511e038714fb5f4fb59c06a8aa6c0281"> SuperCoder7979's 1.16 RC primer (SuperCoder7979, Accessed 2021)</a>
-- <a href="https://github.com/TelepathicGrunt/StructureTutorialMod"> TelepathicGrunt's Structure Tutorial Mod (TelepathicGrunt, Accessed 2021)</a>
-- <a href="https://discord.gg/UvedJ9m"> Official Minecraft Forge Discord (MinecraftForge, Accessed 2021)</a>
+- [SuperCoder7979's 1.16 RC primer (SuperCoder7979, Accessed 2021)](https://gist.github.com/SuperCoder7979/511e038714fb5f4fb59c06a8aa6c0281)
+- [TelepathicGrunt's Structure Tutorial Mod (TelepathicGrunt, Accessed 2021)](https://github.com/TelepathicGrunt/StructureTutorialMod)
+- [Official Minecraft Forge Discord (MinecraftForge, Accessed 2021)](https://discord.gg/UvedJ9m)
 
 *Sourced from https://gist.github.com/50ap5ud5/f4e70f0e8faeddcfde6b4b1df70f83b8*

--- a/primers/1.17/index.md
+++ b/primers/1.17/index.md
@@ -23,7 +23,7 @@ The following are some of the new methods you need to register new TileEntities 
 2. Override `EntityBlock#newBlockEntity` and return a new instance of your block entity
 
 E.g.
-```
+```java
 public class BlockEntityEnabledBlock extends BaseEntityBlock {
 
     public BlockEntityEnabledBlock(BlockBehaviour.Properties properties) {
@@ -55,11 +55,11 @@ If you need separate ticking logic on the client, create another static method t
 
 To return the `BlockEntityTicker` instance, call `BaseEntityBlock$createTickHelper` in the abstract block entity block to create an instance of your Ticker. You can then call the static tick method from your BlockEntity class.
 
-The logical side check can done with a ``Level#isClientSide`` check as normal.
+The logical side check can done with a `Level#isClientSide` check as normal.
 
 E.g. Example below shows us creating a Block class which has a `BlockEntityTicker` for the server side only.
 
-```
+```java
 public class BlockEntityEnabledBlock extends BaseEntityBlock {
 
     public BlockEntityEnabledBlock(BlockBehaviour.Properties properties) {
@@ -73,7 +73,7 @@ public class BlockEntityEnabledBlock extends BaseEntityBlock {
    
     @Override
     @Nullable
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState       state, BlockEntityType<T> type) {
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
         return level.isClientSide() ? null : createTickerHelper(type, ModBlockEntityType.MY_BLOCK_ENTITY.get(), MyModBlockEntity::serverTick);
     }
 
@@ -81,11 +81,11 @@ public class BlockEntityEnabledBlock extends BaseEntityBlock {
 ```
 
 ## TileEntityRenderer
-In the Forge environment, you need to Subscribe to the ``EntityRenderersEvent`` event.
+In the Forge environment, you need to Subscribe to the `EntityRenderersEvent` event.
 
-- Call ``EntityRenderersEvent$RegisterRenderers#registerBlockEntityRenderer`` to register a BlockEntityRenderer
+- Call `EntityRenderersEvent$RegisterRenderers#registerBlockEntityRenderer` to register a BlockEntityRenderer
 - You now need a `BlockEntityRendererProvider$Context` instance as a parameter in the constructor of your BlockEntityRenderer class.
-- You now need a `BlockEntityRendererProvider` instance in the ``registerBlockEntityRenderer`` method, which takes in the ``BlockEntityRendererProvider$Context`` from your BlockEntityRenderer class.
+- You now need a `BlockEntityRendererProvider` instance in the `registerBlockEntityRenderer` method, which takes in the `BlockEntityRendererProvider$Context` from your BlockEntityRenderer class.
 
 
 
@@ -123,7 +123,7 @@ There are now new objects in Entity Models
 **ModelPart**
 - The ModelRenderer or the group/bone
 - Can be multiple parts within a model, and the parts can contain multiple cubes.
-- You can also have each part have childs of other parts meaning that rotation and position applied to this part will also be applied to other parts in a relative fashion
+- You can also have each part have children of other parts meaning that rotation and position applied to this part will also be applied to other parts in a relative fashion
 
 **ModelPart$Cube**
 - The boxes inside the group/bone
@@ -144,7 +144,7 @@ There are now new objects in Entity Models
 
 **LayerDefinition**
 - The definition of the model + texture
-- Needs to be registered during ``EntityRenderersEvent$RegisterLayerDefinitions``
+- Needs to be registered during `EntityRenderersEvent$RegisterLayerDefinitions`
 
 **MaterialDefinition**
 - The definition of the texture data, specifically the size of the texture
@@ -163,11 +163,11 @@ There are now new objects in Entity Models
 - $RegisterRenderers, for registering the entity renderer
 - $AddLayers, for adding layers to a specific entity renderer
 
-You can refer to Forge’s <a href="https://github.com/MinecraftForge/MinecraftForge/blob/1.17.x/src/test/java/net/minecraftforge/debug/client/rendering/EntityRendererEventsTest.java">EntityRendererEventTest</a> for examples.
+You can refer to Forge’s [EntityRendererEventTest](https://github.com/MinecraftForge/MinecraftForge/blob/1.17.x/src/test/java/net/minecraftforge/debug/client/rendering/EntityRendererEventsTest.java) for examples.
 
 Additional community guides can be seen here:
-- <a href="https://gist.github.com/gigaherz/7115024820f55717bc40a6e2247c6aca">Giga’s Explanation</a>
-- <a href="https://github.com/SizableShrimp/EntityModelJson/blob/1.17.x/docs/SCHEMA.json">Shrimp’s Json Spec<a> (jsons for Entity Models aren’t available yet, Shrimp just did some workaround for it)
+- [Giga’s Explanation](https://gist.github.com/gigaherz/7115024820f55717bc40a6e2247c6aca)
+- [Shrimp’s Json Spec](https://github.com/SizableShrimp/EntityModelJson/blob/1.17.x/docs/SCHEMA.json) (jsons for Entity Models aren’t available yet, Shrimp just did some workaround for it)
 ## World Generation
 Most of the core foundations from 1.16 have remained mostly the same. The main changes relate to the technical foundations in preparations for 1.18 Caves and Cliffs generation.
 ### World Height Changes
@@ -219,9 +219,9 @@ Mojang has recently exposed their game test framework, a set of tools which the 
 - Example usage: https://www.youtube.com/watch?v=vXaWOJTCYNg 
 
 Currently there is no API to use it as part of mods, but there are PRs being made to make it usable for modders.
-- <a href="https://github.com/MinecraftForge/MinecraftForge/pull/8024">PR 8024</a>
+- [PR 8024](https://github.com/MinecraftForge/MinecraftForge/pull/8024)
 
-All the components are under the ``net.minecraft.gametest.framework`` package.
+All the components are under the `net.minecraft.gametest.framework` package.
 
 ## Forge API
 ### Full Migration to Mojang Mappings
@@ -243,34 +243,34 @@ Make a backup! If you're not already using some form of Version Control System (
 
 The steps outlined below do not backup your files, and they irreversibly change them. Be warned. Note that you can switch back mappings at any time, but backups are still not made. 
 
-1. Run ``gradlew -PUPDATE_MAPPINGS_CHANNEL="official" -PUPDATE_MAPPINGS="1.16.5"`` updateMappings in a terminal in your mod's project directory. 
-2. Prepend ``./`` if you're using a Unix-based system. 
+1. Run `gradlew -PUPDATE_MAPPINGS_CHANNEL="official" -PUPDATE_MAPPINGS="1.16.5" updateMappings` in a terminal in your mod's project directory. 
+2. Prepend `./` if you're using a Unix-based system. 
 3. Wait for the process to finish. 
-4. Update your mappings in your `build.gradle` and/or `gradle.properties` file and change the mappings line to match something similar to this effect: ``mappings channel: "official", version: "1.16.5"``
+4. Update your mappings in your `build.gradle` and/or `gradle.properties` file and change the mappings line to match something similar to this effect: `mappings channel: "official", version: "1.16.5"`
 5. Refresh or reimport your Gradle project. 
 6. Done! 
 
 Please note that there are still some bugs associated with changing your mappings. Make sure to try building your mod project or running it to see if there are any compilation errors and fix them.
 
-**Note:** You can run `!updatemappings` in the Forge Discord #bot-commands channel to get help switching to another mappings channel. ﻿ 
+**Note:** You can run `!updatemappings` in the Forge Discord #bot-commands channel to get help switching to another mappings channel.
 
-Read more about the <a href="https://gist.github.com/JDLogic/bf16deed3bcf99bd9e1a22eb21148389">updateMappings command here</a>.
+Read more about the [updateMappings command here](https://gist.github.com/JDLogic/bf16deed3bcf99bd9e1a22eb21148389).
 #### Migration of Class Names to Mojang Mappings
 To migrate class names to Mojang Mapping names, it is recommended you have compilable 1.16.5 code, then migrate to Mojang mappings.
 
 The migration script was designed by Forge contributor, SizableShrimp.
 
-See their detailed explanation of the system in their <a href="https://github.com/SizableShrimp/Forge-Class-Remapper">Github repo</a>.
+See their detailed explanation of the system in their [Github repo](https://github.com/SizableShrimp/Forge-Class-Remapper).
 
 There is also a simpler guide written by one of the Forge team members, Gigaherz.
-- <a href="https://gist.github.com/gigaherz/6fc52ee532f36ec432db62458c1620b5">Gigaherz’s class name port steps</a>
+- [Gigaherz’s class name port steps](https://gist.github.com/gigaherz/6fc52ee532f36ec432db62458c1620b5)
 
 ### Separation of Client-Only Methods within Common Classes
 The OnlyIn annotation has now been stripped from all Common code.
 This means methods that used to be client only will no longer crash dedicated servers instantly.
 
 Relevant PRs:
-- <a href="https://github.com/MinecraftForge/MinecraftForge/pull/7773">PR 7773</a> Migrated into 1.17
+- [PR 7773](https://github.com/MinecraftForge/MinecraftForge/pull/7773) Migrated into 1.17
 - #initializeClient which can consume a custom client instance containing properties only available on the client.
 - An anonymous class should be consumed
 
@@ -309,7 +309,7 @@ To use it,
 3. Check your latest log file and copy paste your access token to be used in your other mod development environments.
 ##### Approach 1 - Use Minecraft Instance
 
-```
+```java
 @Mod.EventBusSubscriber(modid = YourMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class ClientEvents {
 
@@ -323,7 +323,7 @@ public class ClientEvents {
 ```
 ##### Approach 2 - Use Mojang Authentication System
 
-```
+```java
 @Mod.EventBusSubscriber(modid = YourMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class ClientEvents {
 
@@ -352,12 +352,12 @@ To use these, register through the class type and a supplier of the class type i
 
 
 E.g. Registering an extension point to mark a client side only mod as client only so that when connecting to servers, it does not think it is required on servers and won’t show the red “cross" icon.
-  ``ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> FMLNetworkConstants.IGNORESERVERONLY, (incoming, isNetwork) -> true));``
+  `ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> FMLNetworkConstants.IGNORESERVERONLY, (incoming, isNetwork) -> true));`
 
 ### HUD Overlay API
 A new HUD Overlay API has been added for 1.17 exclusively. The API does make some breaking changes, so it is not possible to backport to 1.16 in its entirety.
 
-- <a href="https://github.com/MinecraftForge/MinecraftForge/pull/7770">PR 7770</a> Migrated into 1.17
+- [PR 7770](https://github.com/MinecraftForge/MinecraftForge/pull/7770) Migrated into 1.17
 
 This PR adds in OverlayRegistry to register IngameOverlay for an ElementType#Layer
 - Four methods are added which can register the top, bottom, before, or after a particular overlay type, can be enabled or disabled
@@ -372,22 +372,22 @@ This made it confusing for modders so the Forge-provided method isAir(World, Pos
 ### Capabilities
 #### CapabilityToken and @CapabilityInject Deprecation
 Due to Java 16 backend changes and a request to move away from Java reflection, a new way of initialising Capability instances is being added to 1.17 Forge in the future.
-- <a href="https://github.com/MinecraftForge/MinecraftForge/pull/8116"> See Pull Request 8116 for more information </a>.
+- [See Pull Request 8116 for more information](https://github.com/MinecraftForge/MinecraftForge/pull/8116).
 
 **Previous Design**:
-- One would use the ``@CapabilityInject`` annotation on a null field
-```
+- One would use the `@CapabilityInject` annotation on a null field
+```java
 @CapabilityInject(InterfaceForMyCapability.class)
 public static void Capability<InterfaceForMyCapability> CAP_INSTANCE = null;
 ```
 
 **New Design**
 - Introduction of a CapabilityToken object, which can capture generic types, similar to Google’s TypeToken.
-- Capability will now have a ``isRegistered`` function to replace sanity checks of ``!= null``.
-- It also has a addListener(Consumer<Capability>) function, which is analogous too the old @CapabilityInject on a method.
+- Capability will now have a `isRegistered` function to replace sanity checks of `!= null`.
+- It also has a `addListener(Consumer<Capability>)` function, which is analogous too the old @CapabilityInject on a method.
 
 Example use of new design:
-```
+```java
 public static Capability<IDataHolder> DATA_HOLDER_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 ```
 Note that we use an anonymous class. This forces the compiler to include the generic information we need.
@@ -401,7 +401,7 @@ This was originally intended as an easy API hook for other mods to use your capa
 For pre 1.17 mods that used Capabilities, move the code in the write and read methods to your ICapabilitySerializer implementation.
 
 #### RegisterCapabilitiesEvent
-As of <a href="https://github.com/MinecraftForge/MinecraftForge/pull/8021">PR 8021</a> there is now a `RegisterCapabilitiesEvent` that allows you to register capabilities properly.
+As of [PR 8021](https://github.com/MinecraftForge/MinecraftForge/pull/8021) there is now a `RegisterCapabilitiesEvent` that allows you to register capabilities properly.
 
 Please subscribe to the `RegisterCapabilitiesEvent` and use ``RegisterCapabilitiesEvent#register`` for registering capabilities in the future.
 
@@ -437,31 +437,31 @@ In light of the recent Java 17 release, no, Java 17 **_will not_** work on Forge
 **Open GL**
 
 Everything in terms of shaders is done through RenderSystem now
-- ``RenderSystem#setShader`` which includes vertex consumer data and old RenderType things
+- `RenderSystem#setShader` which includes vertex consumer data and old RenderType things
 
-<a href="https://github.com/MinecraftForge/MinecraftForge/commit/80d08dbf3a8e0341962c23dc4737b9af289ef7de">37.0.15</a> added RegisterShadersEvent for registering new shaders
+[37.0.15](https://github.com/MinecraftForge/MinecraftForge/commit/80d08dbf3a8e0341962c23dc4737b9af289ef7de) added RegisterShadersEvent for registering new shaders
 1. First param is a constructed instance of the the event param, the unique name of the shader, and the vertex format
 2. Second param can be used to cache the instance on load
-3. You can see <a href="https://github.com/MinecraftForge/MinecraftForge/blob/80d08dbf3a8e0341962c23dc4737b9af289ef7de/src/main/java/net/minecraftforge/client/ForgeHooksClient.java#L863-L881">ForgeHooksClient</a> for example on usage
+3. You can see [ForgeHooksClient](https://github.com/MinecraftForge/MinecraftForge/blob/80d08dbf3a8e0341962c23dc4737b9af289ef7de/src/main/java/net/minecraftforge/client/ForgeHooksClient.java#L863-L881) for example on usage
 
-See <a href="https://gist.github.com/gigaherz/b8756ff463541f07a644ef8f14cb10f5">Gigaherz’s Guide - How to use Shaders In 1.17<a>
+See [Gigaherz’s Guide - How to use Shaders In 1.17](https://gist.github.com/gigaherz/b8756ff463541f07a644ef8f14cb10f5)
 
 ### Removal of ToolType and Tool System Redesign
 
 The patches Forge made to allow for blocks to have a “correct" tool (be mined faster by certain tools) has now been overhauled. All 1.17 mods will need to change their code to account for this new system.
 
-This new system was designed by Forge team member Gigaherz. This is added through  <a href="https://github.com/MinecraftForge/MinecraftForge/pull/7970">PR 7970</a>, 
+This new system was designed by Forge team member Gigaherz. This is added through [PR 7970](https://github.com/MinecraftForge/MinecraftForge/pull/7970), 
 
-To use this new tool system, please see the <a href="https://gist.github.com/gigaherz/691f528a61f631af90c9426c076a298a"> guide written by Gigaherz </a>.
+To use this new tool system, please see the [guide written by Gigaherz](https://gist.github.com/gigaherz/691f528a61f631af90c9426c076a298a).
 
 A brief summary of the system is as follows:
-- Register a tier by ``TierSortingRegistry#registerTier``, must be initialized before specific item so best to do statically
+- Register a tier by `TierSortingRegistry#registerTier`, must be initialized before specific item so best to do statically
 - Create tier using ForgeTier
 
-Specific actions a tool make take is done by registering a ToolAction via ``ToolAction#get``, defaults in ToolActions.
-- ``Item#isCorrectToolForDrops``. This determines if block can be dropped 
-- ``Item#getDestroySpeed``. Determines how fast the block can be mined
-- ``Item#canPerformAction``. Checks if a particular tool can perform a specific action, currently unused in the vanilla system
+Specific actions a tool make take is done by registering a ToolAction via `ToolAction#get`, defaults in ToolActions.
+- `Item#isCorrectToolForDrops`. This determines if block can be dropped 
+- `Item#getDestroySpeed`. Determines how fast the block can be mined
+- `Item#canPerformAction`. Checks if a particular tool can perform a specific action, currently unused in the vanilla system
 
 There is a datapack override for modpack creators for overriding the sorting list for custom behavior, mods will define within the tier registering
 ## Potential Changes in Forge
@@ -470,7 +470,7 @@ Fluids are getting a complete overhaul in 1.17.
 
 Previously, Fluids were limited to water-like behaviour only due to Mojang hardcoding their water references in many parts of the codebase. Since patching all those references would be major changes, the Fluid Overhaul will only be considered in 1.17 and above.
 
-You can keep track of the PR here: Fluid Overhaul <a href="https://github.com/MinecraftForge/MinecraftForge/pull/7992">PR 7992</a>
+You can keep track of the PR here: Fluid Overhaul [PR 7992](https://github.com/MinecraftForge/MinecraftForge/pull/7992)
 
 ## References and Contributors
 - Gigaherz - various guides and documentation for the 1.17 systems


### PR DESCRIPTION
Goes through the 1.12-1.17 primers and updates them to use proper markdown format and removes any problematic characters. Also fixes some spelling mistakes.